### PR TITLE
🥢 Separate the storage namespace by version

### DIFF
--- a/src/hub/cross-chain/CrossChainRegistryStorageV1.sol
+++ b/src/hub/cross-chain/CrossChainRegistryStorageV1.sol
@@ -24,8 +24,10 @@ contract CrossChainRegistryStorageV1 {
     mapping(uint32 hplDomain => HyperlaneInfo) hyperlanes;
   }
 
-  string constant _NAMESPACE = 'mitosis.storage.CrossChainRegistryStorage.v1';
-  bytes32 public immutable StorageV1Location = _NAMESPACE.storageSlot();
+  string constant _NAMESPACE = 'mitosis.storage.CrossChainRegistryStorage';
+  
+  string public constant _V1_NAMESPACE = string(abi.encodePacked(_NAMESPACE, ".v1"));
+  bytes32 public immutable StorageV1Location = _V1_NAMESPACE.storageSlot();
 
   function _getStorageV1() internal view returns (StorageV1 storage $) {
     bytes32 storageLocation = StorageV1Location;


### PR DESCRIPTION
Separate the storage namespace by version for convenience to adding storage v2 in the future.

What do you think?