### PR TITLE
✨ EOLProtocolRegistry

### DIFF
--- a/src/branch/strategy/StrategyExecutor.sol
+++ b/src/branch/strategy/StrategyExecutor.sol
@@ -274,6 +274,7 @@ contract StrategyExecutor is
       if (enabled[i] == strategyId) {
         if (enabled.length > 1) enabled[i] = enabled[enabled.length - 1];
         enabled.pop();
+        break;
       }
     }
 

--- a/src/hub/eol/EOLProtocolRegistry.sol
+++ b/src/hub/eol/EOLProtocolRegistry.sol
@@ -1,0 +1,131 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.26;
+
+import { Time } from '@oz-v5/utils/types/Time.sol';
+import { EnumerableSet } from '@oz-v5/utils/structs/EnumerableSet.sol';
+import { AccessControlUpgradeable } from '@ozu-v5/access/AccessControlUpgradeable.sol';
+import { OwnableUpgradeable } from '@ozu-v5/access/OwnableUpgradeable.sol';
+import { Ownable2StepUpgradeable } from '@ozu-v5/access/Ownable2StepUpgradeable.sol';
+
+import { EOLProtocolRegistryStorageV1, ProtocolInfo } from './EOLProtocolRegistryStorageV1.sol';
+import { StdError } from '../../lib/StdError.sol';
+
+contract EOLProtocolRegistry is Ownable2StepUpgradeable, AccessControlUpgradeable, EOLProtocolRegistryStorageV1 {
+  using EnumerableSet for EnumerableSet.UintSet;
+
+  event ProtocolRegistered(
+    uint256 indexed protocolId, address indexed eolAsset, uint256 indexed chainId, string name, string metadata
+  );
+  event ProtocolUnregistered(
+    uint256 indexed protocolId, address indexed eolAsset, uint256 indexed chainId, string name
+  );
+
+  event Authorized(address indexed eolAsset, address indexed account);
+  event Unauthorized(address indexed eolAsset, address indexed account);
+
+  error EOLProtocolRegistry_AlreadyRegistered(uint256 protocolId, address eolAsset, uint256 chainId, string name);
+  error EOLProtocolRegistry_NotRegistered(uint256 protocolId);
+
+  //=========== NOTE: INITIALIZATION FUNCTIONS ===========//
+
+  constructor() {
+    _disableInitializers();
+  }
+
+  function initialize(address owner) external initializer {
+    __Ownable2Step_init();
+    _transferOwnership(owner);
+
+    __AccessControl_init();
+    _grantRole(DEFAULT_ADMIN_ROLE, owner);
+  }
+
+  //=========== NOTE: VIEW FUNCTIONS ===========//
+
+  function protocolIds(address eolAsset, uint256 chainId) external view returns (uint256[] memory) {
+    return _getStorageV1().indexes[eolAsset][chainId].protocolIds.values();
+  }
+
+  function protocolId(address eolAsset, uint256 chainId, string memory name) external pure returns (uint256) {
+    return _protocolId(eolAsset, chainId, name);
+  }
+
+  function protocol(uint256 protocolId_) public view returns (ProtocolInfo memory) {
+    return _getStorageV1().protocols[protocolId_];
+  }
+
+  function isProtocolRegistered(uint256 protocolId_) external view returns (bool) {
+    return protocol(protocolId_).protocolId != 0;
+  }
+
+  function isProtocolRegistered(address eolAsset, uint256 chainId, string memory name) external view returns (bool) {
+    return protocol(_protocolId(eolAsset, chainId, name)).protocolId != 0;
+  }
+
+  function isAuthorized(address eolAsset, address account) external view returns (bool) {
+    return _getStorageV1().isAuthorized[eolAsset][account];
+  }
+
+  //=========== NOTE: MUTATION FUNCTIONS ===========//
+
+  function registerProtocol(address eolAsset, uint256 chainId, string memory name, string memory metadata) external {
+    StorageV1 storage $ = _getStorageV1();
+    uint256 id = _protocolId(eolAsset, chainId, name);
+
+    _assertOnlyAuthorized($, eolAsset);
+    if (bytes(name).length == 0) revert StdError.InvalidParameter('name');
+    if ($.protocols[id].protocolId != 0) {
+      revert EOLProtocolRegistry_AlreadyRegistered(id, eolAsset, chainId, name);
+    }
+
+    $.protocols[id] = ProtocolInfo({
+      protocolId: id,
+      eolAsset: eolAsset,
+      chainId: chainId,
+      name: name,
+      metadata: metadata,
+      registeredAt: Time.timestamp()
+    });
+
+    $.indexes[eolAsset][chainId].protocolIds.add(id);
+
+    emit ProtocolRegistered(id, eolAsset, chainId, name, metadata);
+  }
+
+  function unregisterProtocol(uint256 protocolId_) external {
+    StorageV1 storage $ = _getStorageV1();
+    ProtocolInfo storage p = $.protocols[protocolId_];
+
+    if (p.protocolId == 0) revert EOLProtocolRegistry_NotRegistered(protocolId_);
+
+    _assertOnlyAuthorized($, p.eolAsset);
+
+    p.protocolId = 0;
+    $.indexes[p.eolAsset][p.chainId].protocolIds.remove(protocolId_);
+
+    emit ProtocolUnregistered(protocolId_, p.eolAsset, p.chainId, p.name);
+  }
+
+  //=========== NOTE: OWNABLE FUNCTIONS ===========//
+
+  function authorize(address eolAsset, address account) external onlyOwner {
+    _getStorageV1().isAuthorized[eolAsset][account] = true;
+    emit Authorized(eolAsset, account);
+  }
+
+  function unauthorize(address eolAsset, address account) external onlyOwner {
+    _getStorageV1().isAuthorized[eolAsset][account] = false;
+    emit Unauthorized(eolAsset, account);
+  }
+
+  //=========== NOTE: INTERNAL FUNCTIONS ===========//
+
+  function _assertOnlyAuthorized(StorageV1 storage $, address eolAsset) internal view {
+    if (!$.isAuthorized[eolAsset][_msgSender()]) revert StdError.Unauthorized();
+  }
+
+  function _protocolId(address eolAsset, uint256 chainId, string memory name) internal pure returns (uint256) {
+    bytes32 nameHash = keccak256(bytes(name));
+    return uint256(keccak256(abi.encode(eolAsset, chainId, nameHash)));
+  }
+}

--- a/src/hub/eol/EOLProtocolRegistryStorageV1.sol
+++ b/src/hub/eol/EOLProtocolRegistryStorageV1.sol
@@ -1,0 +1,39 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.26;
+
+import { ERC7201Utils } from '../../lib/ERC7201Utils.sol';
+import { EnumerableSet } from '@oz-v5/utils/structs/EnumerableSet.sol';
+
+struct ProtocolInfo {
+  uint256 protocolId;
+  address eolAsset;
+  uint256 chainId;
+  string name;
+  string metadata;
+  uint48 registeredAt;
+}
+
+contract EOLProtocolRegistryStorageV1 {
+  using ERC7201Utils for string;
+
+  struct IndexData {
+    EnumerableSet.UintSet protocolIds;
+  }
+
+  struct StorageV1 {
+    mapping(uint256 protocolId => ProtocolInfo) protocols;
+    mapping(address eolAsset => mapping(uint256 chainId => IndexData)) indexes;
+    mapping(address eolAsset => mapping(address account => bool)) isAuthorized;
+  }
+
+  string private constant _NAMESPACE = 'mitosis.storage.EOLProtocolRegistryStorage.v1';
+  bytes32 private immutable _slot = _NAMESPACE.storageSlot();
+
+  function _getStorageV1() internal view returns (StorageV1 storage $) {
+    bytes32 slot = _slot;
+    // slither-disable-next-line assembly
+    assembly {
+      $.slot := slot
+    }
+  }
+}


### PR DESCRIPTION
This will be used by two contracts:
- `EOLGovernor` (#26): it will register and unregister protocols to `EOLProtocolRegistry`
- `EOLAllocationGovernor`: it will fetch protocol ids from `EOLProtocolRegistry` for gauge voting.