### PR TITLE
♻️  Use `eolVault` Internally Instead of `eolId`

### DIFF
--- a/src/hub/core/AssetManager.sol
+++ b/src/hub/core/AssetManager.sol
@@ -18,17 +18,17 @@ contract AssetManager is IAssetManager, PausableUpgradeable, Ownable2StepUpgrade
   //=========== NOTE: EVENT DEFINITIONS ===========//
 
   event AssetInitialized(uint256 indexed chainId, address asset);
-  event EOLInitialized(uint256 indexed chainId, uint256 eolId, address asset);
+  event EOLInitialized(uint256 indexed chainId, address eolVault, address asset);
 
   event Deposited(uint256 indexed chainId, address indexed asset, address indexed to, uint256 amount);
   event Redeemed(uint256 indexed chainId, address indexed asset, address indexed to, uint256 amount);
 
-  event YieldSettled(uint256 indexed chainId, uint256 indexed eolId, uint256 amount);
-  event LossSettled(uint256 indexed chainId, uint256 indexed eolId, uint256 amount);
-  event ExtraRewardsSettled(uint256 indexed chainId, uint256 indexed eolId, address indexed reward, uint256 amount);
+  event YieldSettled(uint256 indexed chainId, address indexed eolVault, uint256 amount);
+  event LossSettled(uint256 indexed chainId, address indexed eolVault, uint256 amount);
+  event ExtraRewardsSettled(uint256 indexed chainId, address indexed eolVault, address indexed reward, uint256 amount);
 
-  event EOLAllocated(uint256 indexed chainId, uint256 indexed eolId, uint256 amount);
-  event EOLDeallocated(uint256 indexed chainId, uint256 indexed eolId, uint256 amount);
+  event EOLAllocated(uint256 indexed chainId, address indexed eolVault, uint256 amount);
+  event EOLDeallocated(uint256 indexed chainId, address indexed eolVault, uint256 amount);
 
   event AssetPairSet(address hubAsset, uint256 branchChainId, address branchAsset);
   event RewardTreasurySet(address rewardTreasury);
@@ -37,7 +37,7 @@ contract AssetManager is IAssetManager, PausableUpgradeable, Ownable2StepUpgrade
 
   //=========== NOTE: ERROR DEFINITIONS ===========//
 
-  error AssetManager__EOLInsufficient(uint256 eolId);
+  error AssetManager__EOLInsufficient(address eolVault);
   error AssetManager__BranchAssetPairNotExist(address asset);
   error AssetManager__RewardTreasuryNotSet();
 
@@ -85,61 +85,52 @@ contract AssetManager is IAssetManager, PausableUpgradeable, Ownable2StepUpgrade
 
   //=========== NOTE: EOL FUNCTIONS ===========//
 
-  function allocateEOL(uint256 chainId, uint256 eolId, uint256 amount) external {
+  function allocateEOL(uint256 chainId, address eolVault, uint256 amount) external {
     StorageV1 storage $ = _getStorageV1();
 
-    _assertEolIdExist($, eolId);
-    _assertOnlyStrategist($, eolId);
+    _assertOnlyStrategist($, eolVault);
 
-    IMitosisLedger.EOLAmountState memory state = $.mitosisLedger.eolAmountState(eolId);
+    IMitosisLedger.EOLAmountState memory state = $.mitosisLedger.eolAmountState(eolVault);
     if (state.idle < amount) {
-      revert AssetManager__EOLInsufficient(eolId);
+      revert AssetManager__EOLInsufficient(eolVault);
     }
 
-    $.entrypoint.allocateEOL(chainId, eolId, amount);
-    $.mitosisLedger.recordAllocateEOL(eolId, amount);
+    $.entrypoint.allocateEOL(chainId, eolVault, amount);
+    $.mitosisLedger.recordAllocateEOL(eolVault, amount);
 
-    emit EOLAllocated(chainId, eolId, amount);
+    emit EOLAllocated(chainId, eolVault, amount);
   }
 
-  function deallocateEOL(uint256 chainId, uint256 eolId, uint256 amount) external {
+  function deallocateEOL(uint256 chainId, address eolVault, uint256 amount) external {
     StorageV1 storage $ = _getStorageV1();
 
-    _assertEolIdExist($, eolId);
     _assertOnlyEntrypoint($);
 
-    $.mitosisLedger.recordDeallocateEOL(eolId, amount);
+    $.mitosisLedger.recordDeallocateEOL(eolVault, amount);
 
-    emit EOLDeallocated(chainId, eolId, amount);
+    emit EOLDeallocated(chainId, eolVault, amount);
   }
 
-  function settleYield(uint256 chainId, uint256 eolId, uint256 amount) external {
-    StorageV1 storage $ = _getStorageV1();
-
-    _assertEolIdExist($, eolId);
-    _assertOnlyEntrypoint($);
+  function settleYield(uint256 chainId, address eolVault, uint256 amount) external {
+    _assertOnlyEntrypoint(_getStorageV1());
 
     // TODO(ray): we should give a specific portion of yield to hubAsset holders too.
-    _increaseEOLShareValue($, eolId, amount);
+    _increaseEOLShareValue(eolVault, amount);
 
-    emit YieldSettled(chainId, eolId, amount);
+    emit YieldSettled(chainId, eolVault, amount);
   }
 
-  function settleLoss(uint256 chainId, uint256 eolId, uint256 amount) external {
-    StorageV1 storage $ = _getStorageV1();
+  function settleLoss(uint256 chainId, address eolVault, uint256 amount) external {
+    _assertOnlyEntrypoint(_getStorageV1());
 
-    _assertEolIdExist($, eolId);
-    _assertOnlyEntrypoint($);
+    _decreaseEOLShareValue(eolVault, amount);
 
-    _decreaseEOLShareValue($, eolId, amount);
-
-    emit LossSettled(chainId, eolId, amount);
+    emit LossSettled(chainId, eolVault, amount);
   }
 
-  function settleExtraRewards(uint256 chainId, uint256 eolId, address reward, uint256 amount) external {
+  function settleExtraRewards(uint256 chainId, address eolVault, address reward, uint256 amount) external {
     StorageV1 storage $ = _getStorageV1();
 
-    _assertEolIdExist($, eolId);
     _assertBranchAssetPairExist($, chainId, reward);
     _assertRewardTreasurySet($);
     _assertOnlyEntrypoint($);
@@ -150,7 +141,7 @@ contract AssetManager is IAssetManager, PausableUpgradeable, Ownable2StepUpgrade
     IHubAsset(reward).approve(address($.rewardTreasury), amount);
     $.rewardTreasury.deposit(hubAsset, amount, Time.timestamp());
 
-    emit ExtraRewardsSettled(chainId, eolId, reward, amount);
+    emit ExtraRewardsSettled(chainId, eolVault, reward, amount);
   }
 
   //=========== NOTE: OWNABLE FUNCTIONS ===========//
@@ -185,30 +176,25 @@ contract AssetManager is IAssetManager, PausableUpgradeable, Ownable2StepUpgrade
     emit RewardTreasurySet(address(rewardTreasury));
   }
 
-  function initializeEOL(uint256 chainId, uint256 eolId) external onlyOwner {
+  function initializeEOL(uint256 chainId, address eolVault) external onlyOwner {
     StorageV1 storage $ = _getStorageV1();
 
-    _assertEolIdExist($, eolId);
-
-    IEOLVault eolVault = IEOLVault($.mitosisLedger.eolVault(eolId));
-    address hubAsset = eolVault.asset();
+    address hubAsset = IEOLVault(eolVault).asset();
     address branchAsset = $.branchAssets[hubAsset][chainId];
     _assertBranchAssetPairExist($, chainId, branchAsset);
 
-    $.entrypoint.initializeEOL(chainId, eolId, branchAsset);
-    emit EOLInitialized(chainId, eolId, branchAsset);
+    $.entrypoint.initializeEOL(chainId, eolVault, branchAsset);
+    emit EOLInitialized(chainId, eolVault, branchAsset);
   }
 
   //=========== NOTE: INTERNAL FUNCTIONS ===========//
 
-  function _increaseEOLShareValue(StorageV1 storage $, uint256 eolId, uint256 assets) internal {
-    IEOLVault eolVault = IEOLVault($.mitosisLedger.eolVault(eolId));
-    IHubAsset(eolVault.asset()).mint(address(eolVault), assets);
+  function _increaseEOLShareValue(address eolVault, uint256 assets) internal {
+    IHubAsset(IEOLVault(eolVault).asset()).mint(eolVault, assets);
   }
 
-  function _decreaseEOLShareValue(StorageV1 storage $, uint256 eolId, uint256 assets) internal {
-    IEOLVault eolVault = IEOLVault($.mitosisLedger.eolVault(eolId));
-    IHubAsset(eolVault.asset()).burnFrom(address(eolVault), assets);
+  function _decreaseEOLShareValue(address eolVault, uint256 assets) internal {
+    IHubAsset(IEOLVault(eolVault).asset()).burnFrom(eolVault, assets);
   }
 
   function _mint(StorageV1 storage $, uint256 chainId, address asset, address to, uint256 amount) internal {
@@ -225,16 +211,12 @@ contract AssetManager is IAssetManager, PausableUpgradeable, Ownable2StepUpgrade
     if (_msgSender() != address($.entrypoint)) revert StdError.InvalidAddress('entrypoint');
   }
 
-  function _assertEolIdExist(StorageV1 storage $, uint256 eolId) internal view {
-    if ($.mitosisLedger.eolVault(eolId) == address(0)) revert StdError.InvalidId('eolId');
-  }
-
   function _assertBranchAssetPairExist(StorageV1 storage $, uint256 chainId, address branchAsset) internal view {
     if ($.hubAssets[chainId][branchAsset] == address(0)) revert AssetManager__BranchAssetPairNotExist(branchAsset);
   }
 
-  function _assertOnlyStrategist(StorageV1 storage $, uint256 eolId) internal view {
-    if (_msgSender() != $.mitosisLedger.eolStrategist(eolId)) revert StdError.InvalidAddress('strategist');
+  function _assertOnlyStrategist(StorageV1 storage $, address eolVault) internal view {
+    if (_msgSender() != $.mitosisLedger.eolStrategist(eolVault)) revert StdError.InvalidAddress('strategist');
   }
 
   function _assertRewardTreasurySet(StorageV1 storage $) internal view {

--- a/src/hub/core/AssetManagerEntrypoint.sol
+++ b/src/hub/core/AssetManagerEntrypoint.sol
@@ -41,6 +41,11 @@ contract AssetManagerEntrypoint is
     _;
   }
 
+  modifier onlyEolIdAssigned(address eolVault) {
+    if (_ccRegistry.eolId(eolVault) == 0) revert ICrossChainRegistry.ICrossChainRegistry__EolIdNotAssigned();
+    _;
+  }
+
   constructor(address mailbox, address assetManager_, address ccRegistry_) Router(mailbox) initializer {
     _assetManager = IAssetManager(assetManager_);
     _ccRegistry = ICrossChainRegistry(ccRegistry_);
@@ -76,12 +81,13 @@ contract AssetManagerEntrypoint is
     _dispatchToBranch(chainId, enc);
   }
 
-  function initializeEOL(uint256 chainId, uint256 eolId, address branchAsset)
+  function initializeEOL(uint256 chainId, address eolVault, address branchAsset)
     external
     onlyAssetManager
     onlyDispachable(chainId)
+    onlyEolIdAssigned(eolVault)
   {
-    bytes memory enc = MsgInitializeEOL({ eolId: eolId, asset: branchAsset.toBytes32() }).encode();
+    bytes memory enc = MsgInitializeEOL({ eolId: _ccRegistry.eolId(eolVault), asset: branchAsset.toBytes32() }).encode();
     _dispatchToBranch(chainId, enc);
   }
 
@@ -94,12 +100,13 @@ contract AssetManagerEntrypoint is
     _dispatchToBranch(chainId, enc);
   }
 
-  function allocateEOL(uint256 chainId, uint256 eolId, uint256 amount)
+  function allocateEOL(uint256 chainId, address eolVault, uint256 amount)
     external
     onlyAssetManager
     onlyDispachable(chainId)
+    onlyEolIdAssigned(eolVault)
   {
-    bytes memory enc = MsgAllocateEOL({ eolId: eolId, amount: amount }).encode();
+    bytes memory enc = MsgAllocateEOL({ eolId: _ccRegistry.eolId(eolVault), amount: amount }).encode();
     _dispatchToBranch(chainId, enc);
   }
 
@@ -127,22 +134,24 @@ contract AssetManagerEntrypoint is
 
     if (msgType == MsgType.MsgDeallocateEOL) {
       MsgDeallocateEOL memory decoded = msg_.decodeDeallocateEOL();
-      _assetManager.deallocateEOL(chainId, decoded.eolId, decoded.amount);
+      _assetManager.deallocateEOL(chainId, _ccRegistry.eolVault(decoded.eolId), decoded.amount);
     }
 
     if (msgType == MsgType.MsgSettleYield) {
       MsgSettleYield memory decoded = msg_.decodeSettleYield();
-      _assetManager.settleYield(chainId, decoded.eolId, decoded.amount);
+      _assetManager.settleYield(chainId, _ccRegistry.eolVault(decoded.eolId), decoded.amount);
     }
 
     if (msgType == MsgType.MsgSettleLoss) {
       MsgSettleLoss memory decoded = msg_.decodeSettleLoss();
-      _assetManager.settleLoss(chainId, decoded.eolId, decoded.amount);
+      _assetManager.settleLoss(chainId, _ccRegistry.eolVault(decoded.eolId), decoded.amount);
     }
 
     if (msgType == MsgType.MsgSettleExtraRewards) {
       MsgSettleExtraRewards memory decoded = msg_.decodeSettleExtraRewards();
-      _assetManager.settleExtraRewards(chainId, decoded.eolId, decoded.reward.toAddress(), decoded.amount);
+      _assetManager.settleExtraRewards(
+        chainId, _ccRegistry.eolVault(decoded.eolId), decoded.reward.toAddress(), decoded.amount
+      );
     }
   }
 

--- a/src/hub/core/MitosisLedger.sol
+++ b/src/hub/core/MitosisLedger.sol
@@ -9,8 +9,7 @@ import { MitosisLedgerStorageV1 } from './storage/MitosisLedgerStorageV1.sol';
 
 /// Note: This contract stores state related to balances, EOL states.
 contract MitosisLedger is IMitosisLedger, Ownable2StepUpgradeable, MitosisLedgerStorageV1 {
-  event EolIdSet(uint256 eolId, address eolVault);
-  event EolStrategistSet(uint256 eolId, address strategist);
+  event EolStrategistSet(address eolVault, address strategist);
 
   constructor() {
     _disableInitializers();
@@ -25,28 +24,20 @@ contract MitosisLedger is IMitosisLedger, Ownable2StepUpgradeable, MitosisLedger
 
   // CHAIN
 
-  function lastEolId() external view returns (uint256) {
-    return _getStorageV1().lastEolId;
-  }
-
   function getAssetAmount(uint256 chainId, address asset) external view returns (uint256) {
     return _getStorageV1().chainStates[chainId].amounts[asset];
   }
 
-  function eolVault(uint256 eolId) external view returns (address) {
-    return _getStorageV1().eolStates[eolId].eolVault;
+  function eolStrategist(address eolVault) external view returns (address) {
+    return _getStorageV1().eolStates[eolVault].strategist;
   }
 
-  function eolStrategist(uint256 eolId) external view returns (address) {
-    return _getStorageV1().eolStates[eolId].strategist;
+  function eolAmountState(address eolVault) external view returns (IMitosisLedger.EOLAmountState memory) {
+    return _getStorageV1().eolStates[eolVault].eolAmountState;
   }
 
-  function eolAmountState(uint256 eolId) external view returns (IMitosisLedger.EOLAmountState memory) {
-    return _getStorageV1().eolStates[eolId].eolAmountState;
-  }
-
-  function getEOLAllocateAmount(uint256 eolId) external view returns (uint256) {
-    EOLAmountState storage state = _getStorageV1().eolStates[eolId].eolAmountState;
+  function getEOLAllocateAmount(address eolVault) external view returns (uint256) {
+    EOLAmountState storage state = _getStorageV1().eolStates[eolVault].eolAmountState;
     return state.total - state.optOutPending;
   }
 
@@ -54,24 +45,9 @@ contract MitosisLedger is IMitosisLedger, Ownable2StepUpgradeable, MitosisLedger
 
   // EOL management states
 
-  function assignEolId(address eolVault_, address strategist) external returns (uint256 eolId /* auth */ ) {
-    eolId = assignEolId(eolVault_);
-    setEolStrategist(eolId, strategist);
-  }
-
-  function assignEolId(address eolVault_) public returns (uint256 eolId /* auth */ ) {
-    StorageV1 storage $ = _getStorageV1();
-
-    eolId = ++$.lastEolId;
-    $.eolStates[eolId].eolVault = eolVault_;
-    $.eolIdsByVault[eolVault_] = eolId;
-
-    emit EolIdSet(eolId, eolVault_);
-  }
-
-  function setEolStrategist(uint256 eolId, address strategist) public /* auth */ {
-    _getStorageV1().eolStates[eolId].strategist = strategist;
-    emit EolStrategistSet(eolId, strategist);
+  function setEolStrategist(address eolVault, address strategist) public /* auth */ {
+    _getStorageV1().eolStates[eolVault].strategist = strategist;
+    emit EolStrategistSet(eolVault, strategist);
   }
 
   // Asset, EOL balance states
@@ -84,33 +60,33 @@ contract MitosisLedger is IMitosisLedger, Ownable2StepUpgradeable, MitosisLedger
     _getStorageV1().chainStates[chainId].amounts[asset] -= amount;
   }
 
-  function recordOptIn(uint256 eolId, uint256 amount) external /* auth */ {
-    _getStorageV1().eolStates[eolId].eolAmountState.total += amount;
+  function recordOptIn(address eolVault, uint256 amount) external /* auth */ {
+    _getStorageV1().eolStates[eolVault].eolAmountState.total += amount;
   }
 
-  function recordOptOutRequest(uint256 eolId, uint256 amount) external /* auth */ {
-    EOLAmountState storage state = _getStorageV1().eolStates[eolId].eolAmountState;
+  function recordOptOutRequest(address eolVault, uint256 amount) external /* auth */ {
+    EOLAmountState storage state = _getStorageV1().eolStates[eolVault].eolAmountState;
     state.optOutPending += amount;
   }
 
-  function recordAllocateEOL(uint256 eolId, uint256 amount) external /* auth */ {
-    EOLAmountState storage state = _getStorageV1().eolStates[eolId].eolAmountState;
+  function recordAllocateEOL(address eolVault, uint256 amount) external /* auth */ {
+    EOLAmountState storage state = _getStorageV1().eolStates[eolVault].eolAmountState;
     state.idle -= amount;
   }
 
-  function recordDeallocateEOL(uint256 eolId, uint256 amount) external /* auth */ {
-    EOLAmountState storage state = _getStorageV1().eolStates[eolId].eolAmountState;
+  function recordDeallocateEOL(address eolVault, uint256 amount) external /* auth */ {
+    EOLAmountState storage state = _getStorageV1().eolStates[eolVault].eolAmountState;
     state.idle += amount;
   }
 
-  function recordOptOutResolve(uint256 eolId, uint256 amount) external /* auth */ {
-    EOLAmountState storage state = _getStorageV1().eolStates[eolId].eolAmountState;
+  function recordOptOutResolve(address eolVault, uint256 amount) external /* auth */ {
+    EOLAmountState storage state = _getStorageV1().eolStates[eolVault].eolAmountState;
     state.idle -= amount;
     state.optOutResolved += amount;
   }
 
-  function recordOptOutClaim(uint256 eolId, uint256 amount) external /* auth */ {
-    EOLAmountState storage state = _getStorageV1().eolStates[eolId].eolAmountState;
+  function recordOptOutClaim(address eolVault, uint256 amount) external /* auth */ {
+    EOLAmountState storage state = _getStorageV1().eolStates[eolVault].eolAmountState;
     state.optOutPending -= amount;
     state.optOutResolved -= amount;
     state.total -= amount;

--- a/src/hub/core/storage/MitosisLedgerStorageV1.sol
+++ b/src/hub/core/storage/MitosisLedgerStorageV1.sol
@@ -12,17 +12,13 @@ contract MitosisLedgerStorageV1 {
   }
 
   struct EOLState {
-    address eolVault;
     address strategist;
     IMitosisLedger.EOLAmountState eolAmountState;
   }
 
   struct StorageV1 {
-    uint256 lastEolId;
     mapping(uint256 chainId => ChainState state) chainStates;
-    mapping(uint256 eolId => EOLState state) eolStates;
-    // Index
-    mapping(address eolVault => uint256 eolId) eolIdsByVault;
+    mapping(address eolVault => EOLState state) eolStates;
   }
 
   string private constant _NAMESPACE = 'mitosis.storage.MitosisLedgerStorage.v1';

--- a/src/hub/cross-chain/CrossChainRegistry.sol
+++ b/src/hub/cross-chain/CrossChainRegistry.sol
@@ -23,6 +23,7 @@ contract CrossChainRegistry is
 
   event ChainSet(uint256 indexed chainId, uint32 indexed hplDomain, address indexed entrypoint, string name);
   event VaultSet(uint256 indexed chainId, address indexed vault);
+  event EolIdSet(uint256 indexed eolId, address indexed eolVault);
 
   modifier onlyRegisterer() {
     _checkRole(REGISTERER_ROLE);
@@ -76,6 +77,14 @@ contract CrossChainRegistry is
     return _isRegisteredChain(_getStorageV1().chains[chainId_]);
   }
 
+  function eolVault(uint256 eolId_) external view returns (address) {
+    return _getStorageV1().eolVaults[eolId_];
+  }
+
+  function eolId(address eolVault_) external view returns (uint256) {
+    return _getStorageV1().eolIds[eolVault_];
+  }
+
   // Mutative functions
   //
   // TODO: update methods
@@ -112,6 +121,16 @@ contract CrossChainRegistry is
 
     chainInfo.vault = vault_;
     emit VaultSet(chainId_, vault_);
+  }
+
+  function assignEolId(address eolVault_) external onlyRegisterer returns (uint256 eolId_) {
+    StorageV1 storage $ = _getStorageV1();
+
+    eolId_ = ++$.lastEolId;
+    $.eolVaults[eolId_] = eolVault_;
+    $.eolIds[eolVault_] = eolId_;
+
+    emit EolIdSet(eolId_, eolVault_);
   }
 
   function enrollEntrypoint(address hplRouter) external onlyRegisterer {

--- a/src/hub/cross-chain/CrossChainRegistryStorageV1.sol
+++ b/src/hub/cross-chain/CrossChainRegistryStorageV1.sol
@@ -24,6 +24,10 @@ contract CrossChainRegistryStorageV1 {
     uint32[] hplDomains;
     mapping(uint256 chainId => ChainInfo) chains;
     mapping(uint32 hplDomain => HyperlaneInfo) hyperlanes;
+    // EOL ID
+    uint256 lastEolId;
+    mapping(uint256 eolId => address eolVault) eolVaults;
+    mapping(address eolVault => uint256 eolId) eolIds; // Index
   }
 
   string private constant _NAMESPACE = 'mitosis.storage.CrossChainRegistryStorage.v1';

--- a/src/interfaces/hub/core/IAssetManager.sol
+++ b/src/interfaces/hub/core/IAssetManager.sol
@@ -6,19 +6,19 @@ interface IAssetManager {
 
   function redeem(uint256 chainId, address branchAsset, address to, uint256 amount) external;
 
-  function allocateEOL(uint256 chainId, uint256 eolId, uint256 amount) external;
+  function allocateEOL(uint256 chainId, address eolVault, uint256 amount) external;
 
-  function deallocateEOL(uint256 chainId, uint256 eolId, uint256 amount) external;
+  function deallocateEOL(uint256 chainId, address eolVault, uint256 amount) external;
 
-  function settleYield(uint256 chainId, uint256 eolId, uint256 amount) external;
+  function settleYield(uint256 chainId, address eolVault, uint256 amount) external;
 
-  function settleLoss(uint256 chainId, uint256 eolId, uint256 amount) external;
+  function settleLoss(uint256 chainId, address eolVault, uint256 amount) external;
 
-  function settleExtraRewards(uint256 chainId, uint256 eolId, address reward, uint256 amount) external;
+  function settleExtraRewards(uint256 chainId, address eolVault, address reward, uint256 amount) external;
 
   function initializeAsset(uint256 chainId, address hubAsset) external;
 
   function setAssetPair(address hubAsset, uint256 branchChainId, address branchAsset) external;
 
-  function initializeEOL(uint256 chainId, uint256 eolId) external;
+  function initializeEOL(uint256 chainId, address eolVault) external;
 }

--- a/src/interfaces/hub/core/IAssetManagerEntrypoint.sol
+++ b/src/interfaces/hub/core/IAssetManagerEntrypoint.sol
@@ -4,9 +4,9 @@ pragma solidity ^0.8.26;
 interface IAssetManagerEntrypoint {
   function initializeAsset(uint256 chainId, address branchAsset) external;
 
-  function initializeEOL(uint256 chainId, uint256 eolId, address branchAsset) external;
+  function initializeEOL(uint256 chainId, address eolVault, address branchAsset) external;
 
   function redeem(uint256 chainId, address branchAsset, address to, uint256 amount) external;
 
-  function allocateEOL(uint256 chainId, uint256 eolId, uint256 amount) external;
+  function allocateEOL(uint256 chainId, address eolVault, uint256 amount) external;
 }

--- a/src/interfaces/hub/core/IMitosisLedger.sol
+++ b/src/interfaces/hub/core/IMitosisLedger.sol
@@ -23,26 +23,21 @@ interface IMitosisLedger {
     uint256 optOutResolved;
   }
 
-  function lastEolId() external view returns (uint256);
-
   function getAssetAmount(uint256 chainId, address asset) external view returns (uint256);
 
-  function eolVault(uint256 eolId) external view returns (address);
-  function eolStrategist(uint256 eolId) external view returns (address);
-  function eolAmountState(uint256 eolId) external view returns (EOLAmountState memory);
-  function getEOLAllocateAmount(uint256 eolId) external view returns (uint256);
+  function eolStrategist(address eolVault) external view returns (address);
+  function eolAmountState(address eolVault) external view returns (EOLAmountState memory);
+  function getEOLAllocateAmount(address eolVault) external view returns (uint256);
   // EOL management
-  function assignEolId(address eolVault_) external returns (uint256 eolId);
-  function assignEolId(address eolVault_, address strategist) external returns (uint256 eolId);
-  function setEolStrategist(uint256 eolId, address strategist) external;
+  function setEolStrategist(address eolVault, address strategist) external;
   // Asset Record
   function recordDeposit(uint256 chainId, address asset, uint256 amount) external;
   function recordWithdraw(uint256 chainId, address asset, uint256 amount) external;
   // EOL Record
-  function recordOptIn(uint256 eolId, uint256 amount) external;
-  function recordOptOutRequest(uint256 eolId, uint256 amount) external;
-  function recordAllocateEOL(uint256 eolId, uint256 amount) external;
-  function recordDeallocateEOL(uint256 eolId, uint256 amount) external;
-  function recordOptOutResolve(uint256 eolId, uint256 amount) external;
-  function recordOptOutClaim(uint256 eolId, uint256 amount) external;
+  function recordOptIn(address eolVault, uint256 amount) external;
+  function recordOptOutRequest(address eolVault, uint256 amount) external;
+  function recordAllocateEOL(address eolVault, uint256 amount) external;
+  function recordDeallocateEOL(address eolVault, uint256 amount) external;
+  function recordOptOutResolve(address eolVault, uint256 amount) external;
+  function recordOptOutClaim(address eolVault, uint256 amount) external;
 }

--- a/src/interfaces/hub/cross-chain/ICrossChainRegistry.sol
+++ b/src/interfaces/hub/cross-chain/ICrossChainRegistry.sol
@@ -6,6 +6,7 @@ interface ICrossChainRegistry {
   error ICrossChainRegistry__AlreadyRegistered();
   error ICrossChainRegistry__NotEnrolled();
   error ICrossChainRegistry__AlreadyEnrolled();
+  error ICrossChainRegistry__EolIdNotAssigned();
 
   /// @dev Returns all of the registered ChainIDs.
   function chainIds() external view returns (uint256[] memory);
@@ -29,11 +30,17 @@ interface ICrossChainRegistry {
 
   function isRegisteredChain(uint256 chainId) external view returns (bool);
 
+  function eolVault(uint256 eolId_) external view returns (address);
+
+  function eolId(address eolVault_) external view returns (uint256);
+
   /// @dev Sets the chain information including ChainID, name, and Hyperlane domain.
   function setChain(uint256 chainId, string calldata name, uint32 hplDomain, address entrypoint) external;
 
   /// @dev Sets the vault address for a specific ChainID.
   function setVault(uint256 chainId, address vault) external;
+
+  function assignEolId(address eolVault) external returns (uint256 eolId);
 
   /// @dev Sets the Other chain's MitosisVaultEntrypoint addresses.
   function enrollEntrypoint(address hplRouter) external;

--- a/test/hub/MitosisLedger.t.sol
+++ b/test/hub/MitosisLedger.t.sol
@@ -17,6 +17,7 @@ contract TestCrossChainRegistry is Test, Toolkit {
 
   ProxyAdmin internal _proxyAdmin;
   address immutable owner = _addr('owner');
+  address immutable eolVault = _addr('eolVault');
 
   function setUp() public {
     vm.startPrank(owner);
@@ -69,42 +70,40 @@ contract TestCrossChainRegistry is Test, Toolkit {
   }
 
   function test_recordOptIn() public {
-    uint256 eolId = 1;
     uint256 amount = 100 ether;
-    mitosisLedger.recordOptIn(eolId, amount);
-    assertEq(mitosisLedger.getEOLAllocateAmount(eolId), amount);
+    mitosisLedger.recordOptIn(eolVault, amount);
+    assertEq(mitosisLedger.getEOLAllocateAmount(eolVault), amount);
   }
 
   function test_recordOptOut() public {
-    uint256 eolId = 1;
     uint256 amount = 100 ether;
 
-    mitosisLedger.recordOptIn(eolId, amount);
+    mitosisLedger.recordOptIn(eolVault, amount);
 
     uint256 optOutAmount = 10 ether;
 
     IMitosisLedger.EOLAmountState memory state;
 
-    mitosisLedger.recordOptOutRequest(eolId, optOutAmount);
-    state = mitosisLedger.eolAmountState(eolId);
-    assertEq(mitosisLedger.getEOLAllocateAmount(eolId), amount - optOutAmount);
+    mitosisLedger.recordOptOutRequest(eolVault, optOutAmount);
+    state = mitosisLedger.eolAmountState(eolVault);
+    assertEq(mitosisLedger.getEOLAllocateAmount(eolVault), amount - optOutAmount);
     assertEq(state.optOutPending, optOutAmount);
 
-    mitosisLedger.recordDeallocateEOL(eolId, optOutAmount);
-    state = mitosisLedger.eolAmountState(eolId);
-    assertEq(mitosisLedger.getEOLAllocateAmount(eolId), amount - optOutAmount);
+    mitosisLedger.recordDeallocateEOL(eolVault, optOutAmount);
+    state = mitosisLedger.eolAmountState(eolVault);
+    assertEq(mitosisLedger.getEOLAllocateAmount(eolVault), amount - optOutAmount);
     assertEq(state.optOutPending, optOutAmount);
     assertEq(state.idle, optOutAmount);
 
-    mitosisLedger.recordOptOutResolve(eolId, optOutAmount);
-    state = mitosisLedger.eolAmountState(eolId);
-    assertEq(mitosisLedger.getEOLAllocateAmount(eolId), amount - optOutAmount);
+    mitosisLedger.recordOptOutResolve(eolVault, optOutAmount);
+    state = mitosisLedger.eolAmountState(eolVault);
+    assertEq(mitosisLedger.getEOLAllocateAmount(eolVault), amount - optOutAmount);
     assertEq(state.idle, 0);
     assertEq(state.optOutResolved, optOutAmount);
 
-    mitosisLedger.recordOptOutClaim(eolId, optOutAmount);
-    state = mitosisLedger.eolAmountState(eolId);
-    assertEq(mitosisLedger.getEOLAllocateAmount(eolId), amount - optOutAmount);
+    mitosisLedger.recordOptOutClaim(eolVault, optOutAmount);
+    state = mitosisLedger.eolAmountState(eolVault);
+    assertEq(mitosisLedger.getEOLAllocateAmount(eolVault), amount - optOutAmount);
     assertEq(state.optOutPending, 0);
     assertEq(state.idle, 0);
     assertEq(state.optOutResolved, 0);


### PR DESCRIPTION
A PR that changes `eolId` to be used only for HPL communication and internally to use `eolVault`.

Therefore, `eolID` has a cross-chain nature I guess, so I have moved the assign method to `CrossChainRegistry`.