### PR TITLE
♻️ Rename `EOLAllocationGovernor` to `EOLGaugeGovernor`

### DIFF
--- a/src/hub/governance/EOLGaugeGovernor.sol
+++ b/src/hub/governance/EOLGaugeGovernor.sol
@@ -6,18 +6,16 @@ import { EnumerableSet } from '@oz-v5/utils/structs/EnumerableSet.sol';
 import { Ownable2StepUpgradeable } from '@ozu-v5/access/Ownable2StepUpgradeable.sol';
 
 import { IEOLProtocolRegistry } from '../../interfaces/hub/eol/IEOLProtocolRegistry.sol';
-import { IEOLAllocationGovernor } from '../../interfaces/hub/governance/IEOLAllocationGovernor.sol';
+import { IEOLGaugeGovernor } from '../../interfaces/hub/governance/IEOLGaugeGovernor.sol';
 import { ITWABSnapshots } from '../../interfaces/twab/ITWABSnapshots.sol';
 import { Arrays } from '../../lib/Arrays.sol';
 import { StdError } from '../../lib/StdError.sol';
 import { TWABSnapshotsUtils } from '../../lib/TWABSnapshotsUtils.sol';
-import {
-  EOLAllocationGovernorStorageV1, Epoch, EpochVoteInfo, TotalVoteInfo
-} from './EOLAllocationGovernorStorageV1.sol';
+import { EOLGaugeGovernorStorageV1, Epoch, EpochVoteInfo, TotalVoteInfo } from './EOLGaugeGovernorStorageV1.sol';
 
 // TODO(thai): add more view and ownable functions
 
-contract EOLAllocationGovernor is IEOLAllocationGovernor, Ownable2StepUpgradeable, EOLAllocationGovernorStorageV1 {
+contract EOLGaugeGovernor is IEOLGaugeGovernor, Ownable2StepUpgradeable, EOLGaugeGovernorStorageV1 {
   using TWABSnapshotsUtils for ITWABSnapshots;
   using EnumerableSet for EnumerableSet.AddressSet;
   using Arrays for uint256[];
@@ -28,12 +26,12 @@ contract EOLAllocationGovernor is IEOLAllocationGovernor, Ownable2StepUpgradeabl
 
   event EpochPeriodSet(uint32 epochPeriod);
 
-  error EOLAllocationGovernor__EpochNotFound(uint256 epochId);
-  error EOLAllocationGovernor__EpochNotOngoing(uint256 epochId);
+  error EOLGaugeGovernor__EpochNotFound(uint256 epochId);
+  error EOLGaugeGovernor__EpochNotOngoing(uint256 epochId);
 
-  error EOLAllocationGovernor__ZeroGaugesLength();
-  error EOLAllocationGovernor__InvalidGaugesLength(uint256 actual, uint256 expected);
-  error EOLAllocationGovernor__InvalidGaugesSum();
+  error EOLGaugeGovernor__ZeroGaugesLength();
+  error EOLGaugeGovernor__InvalidGaugesLength(uint256 actual, uint256 expected);
+  error EOLGaugeGovernor__InvalidGaugesSum();
 
   //=========== NOTE: INITIALIZATION FUNCTIONS ===========//
 
@@ -127,12 +125,12 @@ contract EOLAllocationGovernor is IEOLAllocationGovernor, Ownable2StepUpgradeabl
     Epoch storage epoch = _ongoingEpoch($);
     EpochVoteInfo storage epochVoteInfo = _getOrInitEpochVoteInfo($, epoch, chainId);
 
-    require(gauges.length > 0, EOLAllocationGovernor__ZeroGaugesLength());
+    require(gauges.length > 0, EOLGaugeGovernor__ZeroGaugesLength());
     require(
       gauges.length == epochVoteInfo.protocolIds.length,
-      EOLAllocationGovernor__InvalidGaugesLength(gauges.length, epochVoteInfo.protocolIds.length)
+      EOLGaugeGovernor__InvalidGaugesLength(gauges.length, epochVoteInfo.protocolIds.length)
     );
-    require(_sum(gauges) == 100, EOLAllocationGovernor__InvalidGaugesSum());
+    require(_sum(gauges) == 100, EOLGaugeGovernor__InvalidGaugesSum());
 
     epochVoteInfo.gaugesByAccount[_msgSender()] = gauges;
 
@@ -163,7 +161,7 @@ contract EOLAllocationGovernor is IEOLAllocationGovernor, Ownable2StepUpgradeabl
 
   function _epoch(StorageV1 storage $, uint256 epochId) internal view returns (Epoch storage) {
     Epoch storage epoch = $.epochs[epochId];
-    require(epoch.id != 0, EOLAllocationGovernor__EpochNotFound(epochId));
+    require(epoch.id != 0, EOLGaugeGovernor__EpochNotFound(epochId));
     return epoch;
   }
 
@@ -171,9 +169,7 @@ contract EOLAllocationGovernor is IEOLAllocationGovernor, Ownable2StepUpgradeabl
     Epoch storage epoch = _epoch($, $.lastEpochId);
     uint48 currentTime = $.eolAsset.clock();
 
-    require(
-      currentTime >= epoch.startsAt && currentTime < epoch.endsAt, EOLAllocationGovernor__EpochNotOngoing(epoch.id)
-    );
+    require(currentTime >= epoch.startsAt && currentTime < epoch.endsAt, EOLGaugeGovernor__EpochNotOngoing(epoch.id));
 
     return epoch;
   }

--- a/src/hub/governance/EOLGaugeGovernorStorageV1.sol
+++ b/src/hub/governance/EOLGaugeGovernorStorageV1.sol
@@ -24,7 +24,7 @@ struct TotalVoteInfo {
   mapping(address account => uint256[] votedEpochIds) votedEpochIdsByAccount;
 }
 
-contract EOLAllocationGovernorStorageV1 {
+contract EOLGaugeGovernorStorageV1 {
   using ERC7201Utils for string;
 
   struct StorageV1 {
@@ -37,7 +37,7 @@ contract EOLAllocationGovernorStorageV1 {
     mapping(uint256 chainId => TotalVoteInfo) totalVoteInfoByChainId;
   }
 
-  string private constant _NAMESPACE = 'mitosis.storage.EOLAllocationGovernorStorage.v1';
+  string private constant _NAMESPACE = 'mitosis.storage.EOLGaugeGovernorStorage.v1';
   bytes32 private immutable _slot = _NAMESPACE.storageSlot();
 
   function _getStorageV1() internal view returns (StorageV1 storage $) {

--- a/src/interfaces/hub/governance/IEOLAllocationGovernor.sol
+++ b/src/interfaces/hub/governance/IEOLAllocationGovernor.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.27;
 
-interface IEOLAllocationGovernor {
+interface IEOLGaugeGovernor {
   function voters(uint256 chainId) external view returns (address[] memory);
 
   function lastEpochId() external view returns (uint256);


### PR DESCRIPTION
<img width="836" alt="image" src="https://github.com/user-attachments/assets/1d956fef-279d-45b8-afad-0f89f583dadd">

I think `EOLGaugeGovernor` fits well to our domain terms.