### PR TITLE
🥢 Fix typo in `AssetManager`

### DIFF
--- a/src/hub/core/AssetManagerEntrypoint.sol
+++ b/src/hub/core/AssetManagerEntrypoint.sol
@@ -36,7 +36,7 @@ contract AssetManagerEntrypoint is
     _;
   }
 
-  modifier onlyDispachable(uint256 chainId) {
+  modifier onlyDispatchable(uint256 chainId) {
     require(_ccRegistry.isRegisteredChain(chainId), ICrossChainRegistry.ICrossChainRegistry__NotRegistered());
     require(_ccRegistry.entrypointEnrolled(chainId), ICrossChainRegistry.ICrossChainRegistry__NotEnrolled());
     _;
@@ -72,7 +72,7 @@ contract AssetManagerEntrypoint is
 
   //=========== NOTE: ASSETMANAGER FUNCTIONS ===========//
 
-  function initializeAsset(uint256 chainId, address branchAsset) external onlyAssetManager onlyDispachable(chainId) {
+  function initializeAsset(uint256 chainId, address branchAsset) external onlyAssetManager onlyDispatchable(chainId) {
     bytes memory enc = MsgInitializeAsset({ asset: branchAsset.toBytes32() }).encode();
     _dispatchToBranch(chainId, enc);
   }
@@ -80,7 +80,7 @@ contract AssetManagerEntrypoint is
   function initializeEOL(uint256 chainId, address eolVault, address branchAsset)
     external
     onlyAssetManager
-    onlyDispachable(chainId)
+    onlyDispatchable(chainId)
   {
     bytes memory enc = MsgInitializeEOL({ eolVault: eolVault.toBytes32(), asset: branchAsset.toBytes32() }).encode();
     _dispatchToBranch(chainId, enc);
@@ -89,7 +89,7 @@ contract AssetManagerEntrypoint is
   function redeem(uint256 chainId, address branchAsset, address to, uint256 amount)
     external
     onlyAssetManager
-    onlyDispachable(chainId)
+    onlyDispatchable(chainId)
   {
     bytes memory enc = MsgRedeem({ asset: branchAsset.toBytes32(), to: to.toBytes32(), amount: amount }).encode();
     _dispatchToBranch(chainId, enc);
@@ -98,7 +98,7 @@ contract AssetManagerEntrypoint is
   function allocateEOL(uint256 chainId, address eolVault, uint256 amount)
     external
     onlyAssetManager
-    onlyDispachable(chainId)
+    onlyDispatchable(chainId)
   {
     bytes memory enc = MsgAllocateEOL({ eolVault: eolVault.toBytes32(), amount: amount }).encode();
     _dispatchToBranch(chainId, enc);


### PR DESCRIPTION
I was referencing it to create a new contract repo.
