### PR TITLE
♻️ Use named return when only necessary

### DIFF
--- a/src/branch/MitosisVaultEntrypoint.sol
+++ b/src/branch/MitosisVaultEntrypoint.sol
@@ -42,15 +42,15 @@ contract MitosisVaultEntrypoint is IMitosisVaultEntrypoint, IMessageRecipient, R
     _enrollRemoteRouter(_mitosisDomain, _mitosisAddr);
   }
 
-  function vault() external view returns (IMitosisVault vault_) {
+  function vault() external view returns (IMitosisVault) {
     return _vault;
   }
 
-  function mitosisDomain() external view returns (uint32 mitosisDomain_) {
+  function mitosisDomain() external view returns (uint32) {
     return _mitosisDomain;
   }
 
-  function mitosisAddr() external view returns (bytes32 mitosisAddr_) {
+  function mitosisAddr() external view returns (bytes32) {
     return _mitosisAddr;
   }
 

--- a/src/branch/strategy/EOLStrategyExecutor.sol
+++ b/src/branch/strategy/EOLStrategyExecutor.sol
@@ -60,55 +60,55 @@ contract EOLStrategyExecutor is
 
   //=========== NOTE: VIEW FUNCTIONS ===========//
 
-  function vault() public view returns (IMitosisVault vault_) {
+  function vault() public view returns (IMitosisVault) {
     return _vault;
   }
 
-  function asset() public view override(IEOLStrategyExecutor, IStrategyDependency) returns (IERC20 asset_) {
+  function asset() public view override(IEOLStrategyExecutor, IStrategyDependency) returns (IERC20) {
     return _asset;
   }
 
-  function hubEOLVault() public view returns (address hubEOLVault_) {
+  function hubEOLVault() public view returns (address) {
     return _hubEOLVault;
   }
 
-  function strategist() external view returns (address strategist_) {
+  function strategist() external view returns (address) {
     return _getStorageV1().strategist;
   }
 
-  function emergencyManager() external view returns (address emergencyManager_) {
+  function emergencyManager() external view returns (address) {
     return _getStorageV1().emergencyManager;
   }
 
-  function getStrategy(uint256 strategyId) external view override returns (Strategy memory strategy) {
+  function getStrategy(uint256 strategyId) external view override returns (Strategy memory) {
     return _getStrategy(_getStorageV1(), strategyId);
   }
 
-  function getStrategy(address implementation) external view override returns (Strategy memory strategy) {
+  function getStrategy(address implementation) external view override returns (Strategy memory) {
     return _getStrategy(_getStorageV1(), implementation);
   }
 
   /**
    * @dev you must need to careful when using this function. If the enabled list is too long, it may cause out of gas
    */
-  function getEnabledStrategyIds() external view override returns (uint256[] memory enabledStrategyIds) {
+  function getEnabledStrategyIds() external view override returns (uint256[] memory) {
     return _getStorageV1().strategies.enabled;
   }
 
-  function isStrategyEnabled(uint256 strategyId) external view returns (bool enabled) {
+  function isStrategyEnabled(uint256 strategyId) external view returns (bool) {
     return _isStrategyEnabled(_getStorageV1(), strategyId);
   }
 
-  function isStrategyEnabled(address implementation) external view returns (bool enabled) {
+  function isStrategyEnabled(address implementation) external view returns (bool) {
     StorageV1 storage $ = _getStorageV1();
     return _isStrategyEnabled($, $.strategies.idxByImpl[implementation]);
   }
 
-  function totalBalance() external view returns (uint256 totalBalance_) {
+  function totalBalance() external view returns (uint256) {
     return _totalBalance(_getStorageV1());
   }
 
-  function lastSettledBalance() external view returns (uint256 lastSettledBalance_) {
+  function lastSettledBalance() external view returns (uint256) {
     return _getStorageV1().lastSettledBalance;
   }
 

--- a/src/hub/Mitosis.sol
+++ b/src/hub/Mitosis.sol
@@ -56,49 +56,49 @@ contract Mitosis is IMitosis, Ownable2StepUpgradeable {
   /**
    * @inheritdoc IMitosis
    */
-  function optOutQueue() external view returns (IOptOutQueue optOutQueue_) {
+  function optOutQueue() external view returns (IOptOutQueue) {
     return _getMitosisStorage().optOutQueue;
   }
 
   /**
    * @inheritdoc IMitosis
    */
-  function assetManager() external view returns (IAssetManager assetManager_) {
+  function assetManager() external view returns (IAssetManager) {
     return _getMitosisStorage().assetManager;
   }
 
   /**
    * @inheritdoc IMitosis
    */
-  function delegationRegistry() external view returns (IDelegationRegistry delegationRegistry_) {
+  function delegationRegistry() external view returns (IDelegationRegistry) {
     return _getMitosisStorage().delegationRegistry;
   }
 
   /**
    * @inheritdoc IMitosis
    */
-  function eolProtocolGovernor() external view returns (IEOLProtocolGovernor eolProtocolGovernor_) {
+  function eolProtocolGovernor() external view returns (IEOLProtocolGovernor) {
     return _getMitosisStorage().eolProtocolGovernor;
   }
 
   /**
    * @inheritdoc IMitosis
    */
-  function eolGaugeGovernor() external view returns (IEOLGaugeGovernor eolGaugeGovernor_) {
+  function eolGaugeGovernor() external view returns (IEOLGaugeGovernor) {
     return _getMitosisStorage().eolGaugeGovernor;
   }
 
   /**
    * @inheritdoc IMitosis
    */
-  function delegationManager(address account) external view returns (address delegationManager_) {
+  function delegationManager(address account) external view returns (address) {
     return _getMitosisStorage().delegationRegistry.delegationManager(account);
   }
 
   /**
    * @inheritdoc IMitosis
    */
-  function defaultDelegatee(address account) external view returns (address defaultDelegatee_) {
+  function defaultDelegatee(address account) external view returns (address) {
     return _getMitosisStorage().delegationRegistry.defaultDelegatee(account);
   }
 

--- a/src/hub/core/AssetManagerEntrypoint.sol
+++ b/src/hub/core/AssetManagerEntrypoint.sol
@@ -45,7 +45,7 @@ contract AssetManagerEntrypoint is IAssetManagerEntrypoint, IMessageRecipient, R
     _transferOwnership(owner_);
   }
 
-  function assetManager() external view returns (IAssetManager assetManger_) {
+  function assetManager() external view returns (IAssetManager) {
     return _assetManager;
   }
 

--- a/src/hub/core/DelegationRegistry.sol
+++ b/src/hub/core/DelegationRegistry.sol
@@ -25,21 +25,21 @@ contract DelegationRegistry is IDelegationRegistry, DelegationRegistryStorageV1,
   /**
    * @inheritdoc IDelegationRegistry
    */
-  function mitosis() external view override returns (address mitosis_) {
+  function mitosis() external view override returns (address) {
     return _getStorageV1().mitosis;
   }
 
   /**
    * @inheritdoc IDelegationRegistry
    */
-  function delegationManager(address account) external view override returns (address delegationManager_) {
+  function delegationManager(address account) external view override returns (address) {
     return _delegationManager(_getStorageV1(), account);
   }
 
   /**
    * @inheritdoc IDelegationRegistry
    */
-  function defaultDelegatee(address account) external view override returns (address defaultDelegatee_) {
+  function defaultDelegatee(address account) external view override returns (address) {
     return _getStorageV1().defaultDelegatees[account];
   }
 
@@ -67,8 +67,8 @@ contract DelegationRegistry is IDelegationRegistry, DelegationRegistryStorageV1,
 
   //========================== NOTE: INTERNAL FUNCTIONS ==========================//
 
-  function _delegationManager(StorageV1 storage $, address account) internal view returns (address delegationManager_) {
-    delegationManager_ = $.delegationManagers[account];
+  function _delegationManager(StorageV1 storage $, address account) internal view returns (address) {
+    address delegationManager_ = $.delegationManagers[account];
     return delegationManager_ == address(0) ? account : delegationManager_; // default to account
   }
 

--- a/src/hub/core/DelegationRegistryStorageV1.sol
+++ b/src/hub/core/DelegationRegistryStorageV1.sol
@@ -15,10 +15,11 @@ abstract contract DelegationRegistryStorageV1 {
   string private constant _NAMESPACE = 'mitosis.storage.DelegationRegistryStorage.v1';
   bytes32 private immutable _slot = _NAMESPACE.storageSlot();
 
-  function _getStorageV1() internal view returns (StorageV1 storage store) {
+  function _getStorageV1() internal view returns (StorageV1 storage $) {
     bytes32 slot = _slot;
+    // slither-disable-next-line assembly
     assembly {
-      store.slot := slot
+      $.slot := slot
     }
   }
 }

--- a/src/hub/core/OptOutQueueStorageV1.sol
+++ b/src/hub/core/OptOutQueueStorageV1.sol
@@ -58,7 +58,7 @@ abstract contract OptOutQueueStorageV1 is IOptOutQueueStorageV1, ContextUpgradea
     return _queue(_getStorageV1(), eolVault).redeemPeriod;
   }
 
-  function getStatus(address eolVault, uint256 reqId) external view returns (RequestStatus status) {
+  function getStatus(address eolVault, uint256 reqId) external view returns (RequestStatus) {
     StorageV1 storage $ = _getStorageV1();
     LibRedeemQueue.Queue storage queue = _queue($, eolVault);
 
@@ -74,12 +74,13 @@ abstract contract OptOutQueueStorageV1 is IOptOutQueueStorageV1, ContextUpgradea
   function getRequest(address eolVault, uint256[] calldata reqIds)
     external
     view
-    returns (IOptOutQueueStorageV1.GetRequestResponse[] memory resp)
+    returns (IOptOutQueueStorageV1.GetRequestResponse[] memory)
   {
     StorageV1 storage $ = _getStorageV1();
     LibRedeemQueue.Queue storage queue = _queue($, eolVault);
 
-    resp = new IOptOutQueueStorageV1.GetRequestResponse[](reqIds.length);
+    IOptOutQueueStorageV1.GetRequestResponse[] memory resp =
+      new IOptOutQueueStorageV1.GetRequestResponse[](reqIds.length);
     for (uint256 i = 0; i < reqIds.length; i++) {
       LibRedeemQueue.Request memory req = queue.get(reqIds[i]);
 
@@ -104,12 +105,13 @@ abstract contract OptOutQueueStorageV1 is IOptOutQueueStorageV1, ContextUpgradea
   function getRequestByReceiver(address eolVault, address receiver, uint256[] calldata idxItemIds)
     external
     view
-    returns (IOptOutQueueStorageV1.GetRequestByIndexResponse[] memory resp)
+    returns (IOptOutQueueStorageV1.GetRequestByIndexResponse[] memory)
   {
     StorageV1 storage $ = _getStorageV1();
     LibRedeemQueue.Queue storage queue = _queue($, eolVault);
 
-    resp = new IOptOutQueueStorageV1.GetRequestByIndexResponse[](idxItemIds.length);
+    IOptOutQueueStorageV1.GetRequestByIndexResponse[] memory resp =
+      new IOptOutQueueStorageV1.GetRequestByIndexResponse[](idxItemIds.length);
     for (uint256 i = 0; i < idxItemIds.length; i++) {
       uint256 indexId = queue.index(receiver).get(idxItemIds[i]);
       LibRedeemQueue.Request memory req = queue.get(indexId);
@@ -157,15 +159,17 @@ abstract contract OptOutQueueStorageV1 is IOptOutQueueStorageV1, ContextUpgradea
     return _queue(_getStorageV1(), eolVault).index(recipient).size;
   }
 
-  function queueOffset(address eolVault, bool simulate) external view returns (uint256 offset) {
+  function queueOffset(address eolVault, bool simulate) external view returns (uint256) {
     LibRedeemQueue.Queue storage queue = _queue(_getStorageV1(), eolVault);
+    uint256 offset;
     if (simulate) (offset,) = queue.searchQueueOffset(queue.totalReservedAssets, block.timestamp);
     else offset = queue.offset;
     return offset;
   }
 
-  function queueIndexOffset(address eolVault, address recipient, bool simulate) external view returns (uint256 offset) {
+  function queueIndexOffset(address eolVault, address recipient, bool simulate) external view returns (uint256) {
     LibRedeemQueue.Queue storage queue = _queue(_getStorageV1(), eolVault);
+    uint256 offset;
     if (simulate) (offset,) = queue.searchIndexOffset(recipient, queue.totalReservedAssets, block.timestamp);
     else offset = queue.index(recipient).offset;
     return offset;

--- a/src/hub/reward/RoutingRewardHandlerStorageV1.sol
+++ b/src/hub/reward/RoutingRewardHandlerStorageV1.sol
@@ -46,42 +46,34 @@ contract RoutingRewardHandlerStorageV1 is IRoutingRewardHandlerStorageV1 {
   /**
    * @inheritdoc IRoutingRewardHandlerStorageV1
    */
-  function distributionType(address eolVault, address reward)
-    external
-    view
-    returns (IRewardHandler.DistributionType distributionType_)
-  {
+  function distributionType(address eolVault, address reward) external view returns (IRewardHandler.DistributionType) {
     return _distributionType(_getStorageV1(), eolVault, reward);
   }
 
   /**
    * @inheritdoc IRoutingRewardHandlerStorageV1
    */
-  function route(address eolVault, address reward) external view returns (IRewardHandler handler_) {
+  function route(address eolVault, address reward) external view returns (IRewardHandler) {
     return _route(_getStorageV1(), eolVault, reward);
   }
 
   /**
    * @inheritdoc IRoutingRewardHandlerStorageV1
    */
-  function defaultHandler(IRewardHandler.DistributionType distributionType_)
-    external
-    view
-    returns (IRewardHandler defaultHandler_)
-  {
+  function defaultHandler(IRewardHandler.DistributionType distributionType_) external view returns (IRewardHandler) {
     return _getStorageV1().defaultHandlers[distributionType_];
   }
 
   /**
    * @inheritdoc IRoutingRewardHandlerStorageV1
    */
-  function allowedHandlers(uint256 offset, uint256 size) external view returns (IRewardHandler[] memory handlers_) {
+  function allowedHandlers(uint256 offset, uint256 size) external view returns (IRewardHandler[] memory) {
     StorageV1 storage $ = _getStorageV1();
 
     uint256 handlersLength = $.allowedHandlers.length();
     if (offset + size > handlersLength) size = handlersLength - offset;
 
-    handlers_ = new IRewardHandler[](size);
+    IRewardHandler[] memory handlers_ = new IRewardHandler[](size);
     for (uint256 i = 0; i < size; i++) {
       handlers_[i] = IRewardHandler($.allowedHandlers.at(offset + i));
     }
@@ -92,7 +84,7 @@ contract RoutingRewardHandlerStorageV1 is IRoutingRewardHandlerStorageV1 {
   /**
    * @inheritdoc IRoutingRewardHandlerStorageV1
    */
-  function isHandlerAllowed(IRewardHandler handler_) external view returns (bool isRegistered_) {
+  function isHandlerAllowed(IRewardHandler handler_) external view returns (bool) {
     return _isHandlerAllowed(_getStorageV1(), handler_);
   }
 
@@ -162,22 +154,18 @@ contract RoutingRewardHandlerStorageV1 is IRoutingRewardHandlerStorageV1 {
   function _distributionType(StorageV1 storage $, address eolVault, address reward)
     internal
     view
-    returns (IRewardHandler.DistributionType distributionType_)
+    returns (IRewardHandler.DistributionType)
   {
     HandlerConfig memory config = $.handlerConfigs[eolVault][reward];
     return address(config.handler) != address(0) ? config.handler.distributionType() : config.distributionType;
   }
 
-  function _route(StorageV1 storage $, address eolVault, address reward)
-    internal
-    view
-    returns (IRewardHandler handler_)
-  {
+  function _route(StorageV1 storage $, address eolVault, address reward) internal view returns (IRewardHandler) {
     HandlerConfig memory config = $.handlerConfigs[eolVault][reward];
     return address(config.handler) != address(0) ? config.handler : $.defaultHandlers[config.distributionType];
   }
 
-  function _isHandlerAllowed(StorageV1 storage $, IRewardHandler handler_) internal view returns (bool isRegistered_) {
+  function _isHandlerAllowed(StorageV1 storage $, IRewardHandler handler_) internal view returns (bool) {
     return $.allowedHandlers.contains(address(handler_));
   }
 

--- a/src/hub/reward/TreasuryStorageV1.sol
+++ b/src/hub/reward/TreasuryStorageV1.sol
@@ -38,7 +38,7 @@ contract TreasuryStorageV1 is ITreasuryStorageV1 {
   /**
    * @inheritdoc ITreasuryStorageV1
    */
-  function balances(address eolVault, address reward) external view returns (uint256 balance) {
+  function balances(address eolVault, address reward) external view returns (uint256) {
     return _balances(_getStorageV1(), eolVault, reward);
   }
 
@@ -48,14 +48,14 @@ contract TreasuryStorageV1 is ITreasuryStorageV1 {
   function history(address eolVault, address reward, uint256 offset, uint256 size)
     external
     view
-    returns (HistoryResponse[] memory history_)
+    returns (HistoryResponse[] memory)
   {
     StorageV1 storage $ = _getStorageV1();
 
     uint256 historyLength = $.history[eolVault][reward].length;
     if (offset + size > historyLength) size = historyLength - offset;
 
-    history_ = new HistoryResponse[](size);
+    HistoryResponse[] memory history_ = new HistoryResponse[](size);
     for (uint256 i = 0; i < size; i++) {
       Log memory log = $.history[eolVault][reward][offset + i];
       history_[i] = HistoryResponse(log.timestamp, log.amount, log.sign);
@@ -66,7 +66,7 @@ contract TreasuryStorageV1 is ITreasuryStorageV1 {
 
   // ============================ NOTE: INTERNAL FUNCTIONS ============================ //
 
-  function _balances(StorageV1 storage $, address eolVault, address reward) internal view returns (uint256 balance) {
+  function _balances(StorageV1 storage $, address eolVault, address reward) internal view returns (uint256) {
     return $.balances[eolVault][reward];
   }
 }

--- a/src/interfaces/branch/IMitosisVaultEntrypoint.sol
+++ b/src/interfaces/branch/IMitosisVaultEntrypoint.sol
@@ -4,11 +4,11 @@ pragma solidity ^0.8.27;
 import { IMitosisVault } from './IMitosisVault.sol';
 
 interface IMitosisVaultEntrypoint {
-  function vault() external view returns (IMitosisVault vault_);
+  function vault() external view returns (IMitosisVault);
 
-  function mitosisDomain() external view returns (uint32 mitosisDomain_);
+  function mitosisDomain() external view returns (uint32);
 
-  function mitosisAddr() external view returns (bytes32 mitosisAddr_);
+  function mitosisAddr() external view returns (bytes32);
 
   function deposit(address asset, address to, uint256 amount) external;
 

--- a/src/interfaces/branch/strategy/IEOLStrategyExecutor.sol
+++ b/src/interfaces/branch/strategy/IEOLStrategyExecutor.sol
@@ -42,14 +42,14 @@ interface IEOLStrategyExecutor {
   // storage v1
   function strategist() external view returns (address strategist_);
 
-  function getStrategy(uint256 strategyId) external view returns (Strategy memory strategy);
-  function getStrategy(address implementation) external view returns (Strategy memory strategy);
-  function getEnabledStrategyIds() external view returns (uint256[] memory strategyIds);
-  function isStrategyEnabled(uint256 strategyId) external view returns (bool enabled);
-  function isStrategyEnabled(address implementation) external view returns (bool enabled);
+  function getStrategy(uint256 strategyId) external view returns (Strategy memory);
+  function getStrategy(address implementation) external view returns (Strategy memory);
+  function getEnabledStrategyIds() external view returns (uint256[] memory);
+  function isStrategyEnabled(uint256 strategyId) external view returns (bool);
+  function isStrategyEnabled(address implementation) external view returns (bool);
 
-  function totalBalance() external view returns (uint256 totalBalance_);
-  function lastSettledBalance() external view returns (uint256 lastSettledBalance_);
+  function totalBalance() external view returns (uint256);
+  function lastSettledBalance() external view returns (uint256);
 
   function fetchEOL(uint256 amount) external;
   function returnEOL(uint256 amount) external;

--- a/src/interfaces/hub/IMitosis.sol
+++ b/src/interfaces/hub/IMitosis.sol
@@ -16,49 +16,42 @@ interface IMitosis {
 
   /**
    * @notice Returns the address of the OptOutQueue contract.
-   * @return optOutQueue_ The address of the OptOutQueue contract.
    */
-  function optOutQueue() external view returns (IOptOutQueue optOutQueue_);
+  function optOutQueue() external view returns (IOptOutQueue);
 
   /**
    * @notice Returns the address of the AssetManager contract.
-   * @return assetManager_ The address of the AssetManager contract.
    */
-  function assetManager() external view returns (IAssetManager assetManager_);
+  function assetManager() external view returns (IAssetManager);
 
   /**
    * @notice Returns the address of the DelegationRegistry contract.
-   * @return delegationRegistry_ The address of the DelegationRegistry contract.
    */
-  function delegationRegistry() external view returns (IDelegationRegistry delegationRegistry_);
+  function delegationRegistry() external view returns (IDelegationRegistry);
 
   /**
    * @notice Returns the address of the EOLProtocolGovernor contract.
-   * @return eolProtocolGovernor_ The address of the EOLProtocolGovernor contract.
    */
-  function eolProtocolGovernor() external view returns (IEOLProtocolGovernor eolProtocolGovernor_);
+  function eolProtocolGovernor() external view returns (IEOLProtocolGovernor);
 
   /**
    * @notice Returns the address of the EOLGaugeGovernor contract.
-   * @return eolGaugeGovernor_ The address of the EOLGaugeGovernor contract.
    */
-  function eolGaugeGovernor() external view returns (IEOLGaugeGovernor eolGaugeGovernor_);
+  function eolGaugeGovernor() external view returns (IEOLGaugeGovernor);
 
   //====================== NOTE: DELEGATION ======================//
 
   /**
    * @notice Returns the address of the delegation manager for the specified account.
    * @param account The account address
-   * @return delegationManager_ The address of the delegation manager.
    */
-  function delegationManager(address account) external view returns (address delegationManager_);
+  function delegationManager(address account) external view returns (address);
 
   /**
    * @notice Returns the address of the default delegatee for the specified account.
    * @param account The account address
-   * @return defaultDelegatee_ The address of the default delegatee.
    */
-  function defaultDelegatee(address account) external view returns (address defaultDelegatee_);
+  function defaultDelegatee(address account) external view returns (address);
 
   /**
    * @notice Sets the delegation manager for the specified account.

--- a/src/interfaces/hub/core/IAssetManager.sol
+++ b/src/interfaces/hub/core/IAssetManager.sol
@@ -43,77 +43,67 @@ interface IAssetManagerStorageV1 {
 
   /**
    * @notice Get the current entrypoint address (see IAssetManagerEntrypoint)
-   * @return entrypoint_ The address of the current entrypoint
    */
-  function entrypoint() external view returns (address entrypoint_);
+  function entrypoint() external view returns (address);
 
   /**
    * @notice Get the current opt-out queue address (see IOptOutQueue)
-   * @return optOutQueue_ The address of the current opt-out queue
    */
-  function optOutQueue() external view returns (address optOutQueue_);
+  function optOutQueue() external view returns (address);
 
   /**
    * @notice Get the current reward handler address (see IRewardHandler)
-   * @return rewardHandler_ The address of the current reward handler
    */
-  function rewardHandler() external view returns (address rewardHandler_);
+  function rewardHandler() external view returns (address);
 
   /**
    * @notice Get the branch asset address for a given hub asset and chain ID
    * @param hubAsset_ The address of the hub asset
    * @param chainId The ID of the chain
-   * @return branchAsset_ The address of the corresponding branch asset
    */
-  function branchAsset(address hubAsset_, uint256 chainId) external view returns (address branchAsset_);
+  function branchAsset(address hubAsset_, uint256 chainId) external view returns (address);
 
   /**
    * @notice Get the hub asset address for a given chain ID and branch asset
    * @param chainId The ID of the chain
    * @param branchAsset_ The address of the branch asset
-   * @return hubAsset_ The address of the corresponding hub asset
    */
-  function hubAsset(uint256 chainId, address branchAsset_) external view returns (address hubAsset_);
+  function hubAsset(uint256 chainId, address branchAsset_) external view returns (address);
 
   /**
    * @notice Get the total collateral amount of branch asset for a given chain ID and hub asset.
    * @dev The collateral amount is equals to the total amount of branch asset deposited to the MitosisVault
    * @param chainId The ID of the chain
    * @param hubAsset_ The address of the hub asset
-   * @return collateral_ The amount of collateral
    */
-  function collateral(uint256 chainId, address hubAsset_) external view returns (uint256 collateral_);
+  function collateral(uint256 chainId, address hubAsset_) external view returns (uint256);
 
   /**
    * @notice Check if an EOLVault is initialized for a given chain and branch asset (EOLVault -> hubAsset -> branchAsset)
    * @param chainId The ID of the chain
    * @param eolVault The address of the EOLVault
-   * @return eolInitialized_ A boolean indicating whether the EOLVault is initialized
    */
-  function eolInitialized(uint256 chainId, address eolVault) external view returns (bool eolInitialized_);
+  function eolInitialized(uint256 chainId, address eolVault) external view returns (bool);
 
   /**
    * @notice Get the idle balance of an EOLVault
    * @dev The idle balance will be calculated like this:
    * @dev (total opt-in amount - total utilized amount - total pending opt-out amount)
    * @param eolVault The address of the EOLVault
-   * @return eolVaultIdleBalance The idle balance of the EOLVault
    */
-  function eolIdle(address eolVault) external view returns (uint256 eolVaultIdleBalance);
+  function eolIdle(address eolVault) external view returns (uint256);
 
   /**
    * @notice Get the total utilized balance (hubAsset/branchAsset) of an EOLVault
    * @param eolVault The address of the EOLVault
-   * @return eolVaultAllocation Total allocated token amount
    */
-  function eolAlloc(address eolVault) external view returns (uint256 eolVaultAllocation);
+  function eolAlloc(address eolVault) external view returns (uint256);
 
   /**
    * @notice Get the strategist address for an EOLVault
    * @param eolVault The address of the EOLVault
-   * @return strategist_ The address of the strategist
    */
-  function strategist(address eolVault) external view returns (address strategist_);
+  function strategist(address eolVault) external view returns (address);
 }
 
 /**

--- a/src/interfaces/hub/core/IAssetManagerEntrypoint.sol
+++ b/src/interfaces/hub/core/IAssetManagerEntrypoint.sol
@@ -12,10 +12,9 @@ import { IAssetManager } from './IAssetManager.sol';
  */
 interface IAssetManagerEntrypoint is IMessageRecipient {
   /**
-   * @notice Returns the associated Asset Manager contract
-   * @return assetManger_ The address of the Asset Manager contract
+   * @notice Returns the address of the associated Asset Manager contract
    */
-  function assetManager() external view returns (IAssetManager assetManger_);
+  function assetManager() external view returns (IAssetManager);
 
   /**
    * @notice Retrieves the Hyperlane domain for a given chain ID

--- a/src/interfaces/hub/core/IDelegationRegistry.sol
+++ b/src/interfaces/hub/core/IDelegationRegistry.sol
@@ -32,23 +32,20 @@ interface IDelegationRegistry {
 
   /**
    * @dev Queries the Mitosis contract
-   * @return mitosis_ The Mitosis contract
    */
-  function mitosis() external view returns (address mitosis_);
+  function mitosis() external view returns (address);
 
   /**
    * @dev Queries the delegation manager for `account`
    * @param account The account to query
-   * @return delegationManager_ The delegation manager for `account`
    */
-  function delegationManager(address account) external view returns (address delegationManager_);
+  function delegationManager(address account) external view returns (address);
 
   /**
    * @dev Queries the default delegatee for `account`
    * @param account The account to query
-   * @return defaultDelegatee_ The default delegatee for `account`
    */
-  function defaultDelegatee(address account) external view returns (address defaultDelegatee_);
+  function defaultDelegatee(address account) external view returns (address);
 
   /**
    * @dev Sets the delegation manager for `account`. Must emit the {DelegationManagerSet} event.

--- a/src/interfaces/hub/core/IOptOutQueue.sol
+++ b/src/interfaces/hub/core/IOptOutQueue.sol
@@ -101,35 +101,28 @@ interface IOptOutQueueStorageV1 {
 
   /**
    * @notice Retrieves the current asset manager address
-   * @return assetManager_ Address of the current asset manager
    */
-  function assetManager() external view returns (address assetManager_);
+  function assetManager() external view returns (address);
 
   /**
-   * @notice Gets the redeem period duration for a specific EOLVault
+   * @notice Gets the redeem period duration in seconds for a specific EOLVault
    * @param eolVault Address of the EOLVault to query
-   * @return redeemPeriod_ Duration of the redeem period in seconds
    */
-  function redeemPeriod(address eolVault) external view returns (uint256 redeemPeriod_);
+  function redeemPeriod(address eolVault) external view returns (uint256);
 
   /**
    * @notice Retrieves the status of a specific opt-out request
    * @param eolVault Address of the EOLVault to query
    * @param reqId ID of the request to query
-   * @return status RequestStatus enumeration indicating the request status
    */
-  function getStatus(address eolVault, uint256 reqId) external view returns (RequestStatus status);
+  function getStatus(address eolVault, uint256 reqId) external view returns (RequestStatus);
 
   /**
    * @notice Retrieves details for multiple requests from a specific EOLVault
    * @param eolVault Address of the EOLVault to query
    * @param reqIds Array of request IDs to retrieve
-   * @return resp Array of GetRequestResponse structs containing request details
    */
-  function getRequest(address eolVault, uint256[] calldata reqIds)
-    external
-    view
-    returns (GetRequestResponse[] memory resp);
+  function getRequest(address eolVault, uint256[] calldata reqIds) external view returns (GetRequestResponse[] memory);
 
   /**
    * @notice Gets details for multiple requests for a specific receiver from an EOLVault
@@ -137,12 +130,11 @@ interface IOptOutQueueStorageV1 {
    * @param eolVault Address of the EOLVault to query
    * @param receiver Address of the receiver to query
    * @param idxItemIds Array of index item IDs to retrieve
-   * @return resp Array of GetRequestByIndexResponse structs containing request details
    */
   function getRequestByReceiver(address eolVault, address receiver, uint256[] calldata idxItemIds)
     external
     view
-    returns (GetRequestByIndexResponse[] memory resp);
+    returns (GetRequestByIndexResponse[] memory);
 
   /**
    * @notice Retrieves the timestamp when a specific request was reserved
@@ -166,70 +158,62 @@ interface IOptOutQueueStorageV1 {
    * @notice Retrieves the number of shares for a specific request
    * @param eolVault Address of the EOLVault to query
    * @param reqId ID of the request to query
-   * @return shares Number of shares for the specified request
    */
-  function requestShares(address eolVault, uint256 reqId) external view returns (uint256 shares);
+  function requestShares(address eolVault, uint256 reqId) external view returns (uint256);
 
   /**
    * @notice Gets the amount of assets for a specific request
    * @param eolVault Address of the EOLVault to query
    * @param reqId ID of the request to query
-   * @return assets Amount of assets for the specified request
    */
-  function requestAssets(address eolVault, uint256 reqId) external view returns (uint256 assets);
+  function requestAssets(address eolVault, uint256 reqId) external view returns (uint256);
 
   /**
    * @notice Retrieves the current size of the queue for a specific EOLVault
+   * @dev The queue size is the total number of requests in the queue
    * @param eolVault Address of the EOLVault to query the queue
-   * @return size Total request count in the queue
    */
-  function queueSize(address eolVault) external view returns (uint256 size);
+  function queueSize(address eolVault) external view returns (uint256);
 
   /**
    * @notice Gets the size of the queue index for a specific recipient in an EOLVault
    * @param eolVault Address of the EOLVault to query the queue
    * @param recipient Address of the recipient to query the index for
-   * @return size Current size of the queue index for the specified recipient
    */
-  function queueIndexSize(address eolVault, address recipient) external view returns (uint256 size);
+  function queueIndexSize(address eolVault, address recipient) external view returns (uint256);
 
   /**
    * @notice Retrieves the current or simulated offset of the queue for an EOLVault
    * @param eolVault Address of the EOLVault to query
    * @param simulate If true, returns the simulated offset based on current timestamp
-   * @return offset Current or simulated queue offset
    */
-  function queueOffset(address eolVault, bool simulate) external view returns (uint256 offset);
+  function queueOffset(address eolVault, bool simulate) external view returns (uint256);
 
   /**
    * @notice Gets the current or simulated offset of the queue index for a recipient in an EOLVault
    * @param eolVault Address of the EOLVault to query
    * @param recipient Address of the recipient to query
    * @param simulate If true, returns the simulated offset based on current timestamp
-   * @return offset Current or simulated queue index offset
    */
-  function queueIndexOffset(address eolVault, address recipient, bool simulate) external view returns (uint256 offset);
+  function queueIndexOffset(address eolVault, address recipient, bool simulate) external view returns (uint256);
 
   /**
    * @notice Retrieves the total amount of reserved assets for an EOLVault's queue
    * @param eolVault Address of the EOLVault to query
-   * @return totalReserved_ Total amount of reserved assets
    */
-  function totalReserved(address eolVault) external view returns (uint256 totalReserved_);
+  function totalReserved(address eolVault) external view returns (uint256);
 
   /**
    * @notice Gets the total amount of claimed assets for an EOLVault's queue
    * @param eolVault Address of the EOLVault to query
-   * @return totalClaimed_ Total amount of claimed assets
    */
-  function totalClaimed(address eolVault) external view returns (uint256 totalClaimed_);
+  function totalClaimed(address eolVault) external view returns (uint256);
 
   /**
    * @notice Retrieves the total amount of pending assets for an EOLVault's queue
    * @param eolVault Address of the EOLVault to query
-   * @return totalPending_ Total amount of pending assets
    */
-  function totalPending(address eolVault) external view returns (uint256 totalPending_);
+  function totalPending(address eolVault) external view returns (uint256);
 
   /**
    * @notice Gets the reserve history entry for a specific index in an EOLVault
@@ -245,16 +229,14 @@ interface IOptOutQueueStorageV1 {
   /**
    * @notice Retrieves the number of entries in the reserve history for an EOLVault
    * @param eolVault Address of the EOLVault to query
-   * @return length Number of entries in the reserve history
    */
-  function reserveHistoryLength(address eolVault) external view returns (uint256 length);
+  function reserveHistoryLength(address eolVault) external view returns (uint256);
 
   /**
    * @notice Checks if the opt-out queue is enabled for a specific EOLVault
    * @param eolVault Address of the EOLVault to query
-   * @return enabled Boolean indicating whether the queue is enabled
    */
-  function isEnabled(address eolVault) external view returns (bool enabled);
+  function isEnabled(address eolVault) external view returns (bool);
 }
 
 /**

--- a/src/interfaces/hub/eol/IEOLVault.sol
+++ b/src/interfaces/hub/eol/IEOLVault.sol
@@ -16,9 +16,8 @@ interface IEOLVaultStorageV1 {
 
   /**
    * @notice Returns the address of the current asset manager.
-   * @return assetManager_ The address of the asset manager.
    */
-  function assetManager() external view returns (address assetManager_);
+  function assetManager() external view returns (address);
 }
 
 /**

--- a/src/interfaces/hub/governance/IEOLGaugeGovernor.sol
+++ b/src/interfaces/hub/governance/IEOLGaugeGovernor.sol
@@ -67,7 +67,7 @@ interface IEOLGaugeGovernor {
   function protocolIds(address eolVault, uint256 epochId, uint256 chainId) external view returns (uint256[] memory);
 
   /**
-   * @notice Returns the total number of voters for a specific EOLVault and chain.
+   * @notice Returns the addresses of voters for a specific EOLVault and chain.
    * @param eolVault The address of the EOLVault.
    * @param chainId The ID of the chain.
    */

--- a/src/interfaces/hub/governance/IEOLProtocolGovernor.sol
+++ b/src/interfaces/hub/governance/IEOLProtocolGovernor.sol
@@ -99,9 +99,8 @@ interface IEOLProtocolGovernor {
    * @notice Returns the vote option casted by an account for a given proposal ID
    * @param proposalId_ The proposal ID
    * @param account Voter account
-   * @return option The vote option casted by the account
    */
-  function voteOption(uint256 proposalId_, address account) external view returns (VoteOption option);
+  function voteOption(uint256 proposalId_, address account) external view returns (VoteOption);
 
   //=========== NOTE: MUTATIVE FUNCTIONS ===========//
 

--- a/src/interfaces/hub/reward/IMerkleRewardDistributor.sol
+++ b/src/interfaces/hub/reward/IMerkleRewardDistributor.sol
@@ -18,12 +18,8 @@ interface IMerkleRewardDistributorStorageV1 {
    * @param eolVault The EOLVault address
    * @param reward The reward token address
    * @param stageNum The stage number
-   * @return stage_ The stage info for the distribution
    */
-  function stage(address eolVault, address reward, uint256 stageNum)
-    external
-    view
-    returns (StageResponse memory stage_);
+  function stage(address eolVault, address reward, uint256 stageNum) external view returns (StageResponse memory);
 }
 
 /**

--- a/src/interfaces/hub/reward/IRewardDistributor.sol
+++ b/src/interfaces/hub/reward/IRewardDistributor.sol
@@ -30,21 +30,16 @@ interface IRewardDistributor is IRewardHandler {
    * @param account The account address
    * @param reward The reward token address
    * @param metadata The encoded metadata
-   * @return claimable_ True if the account can claim
    */
-  function claimable(address account, address reward, bytes calldata metadata) external view returns (bool claimable_);
+  function claimable(address account, address reward, bytes calldata metadata) external view returns (bool);
 
   /**
    * @notice Returns the amount of claimable rewards for the account.
    * @param account The account address
    * @param reward The reward token address
    * @param metadata The encoded metadata
-   * @return claimableAmount_ The amount of claimable rewards
    */
-  function claimableAmount(address account, address reward, bytes calldata metadata)
-    external
-    view
-    returns (uint256 claimableAmount_);
+  function claimableAmount(address account, address reward, bytes calldata metadata) external view returns (uint256);
 
   /**
    * @notice Claims all of the rewards for the specified vault and reward.

--- a/src/interfaces/hub/reward/IRewardHandler.sol
+++ b/src/interfaces/hub/reward/IRewardHandler.sol
@@ -20,27 +20,23 @@ interface IRewardHandler {
 
   /**
    * @notice Returns the type of the reward handler
-   * @return handlerType_ The type of the reward handler
    */
-  function handlerType() external view returns (HandlerType handlerType_);
+  function handlerType() external view returns (HandlerType);
 
   /**
    * @notice Returns the distribution type of the reward handler
-   * @return distributionType_ The distribution type of the reward handler
    */
-  function distributionType() external view returns (DistributionType distributionType_);
+  function distributionType() external view returns (DistributionType);
 
   /**
    * @notice Returns the description of the reward handler
-   * @return description_ The description of the reward handler
    */
-  function description() external view returns (string memory description_);
+  function description() external view returns (string memory);
 
   /**
    * @notice Checks if the specified dispatcher is allowed to call `handleReward`
-   * @return isDispatchable_ True if the dispatcher is allowed to call `handleReward`
    */
-  function isDispatchable(address dispatcher) external view returns (bool isDispatchable_);
+  function isDispatchable(address dispatcher) external view returns (bool);
 
   /**
    * @notice Handles the distribution of rewards for the specified vault and reward

--- a/src/interfaces/hub/reward/IRoutingRewardHandler.sol
+++ b/src/interfaces/hub/reward/IRoutingRewardHandler.sol
@@ -30,46 +30,35 @@ interface IRoutingRewardHandlerStorageV1 {
    * @notice Returns the distribution type of the reward handler for the given EOLVault and reward
    * @param eolVault The EOLVault address
    * @param reward The reward token address
-   * @return distributionType_ The distribution type of the reward handler
    */
-  function distributionType(address eolVault, address reward)
-    external
-    view
-    returns (IRewardHandler.DistributionType distributionType_);
+  function distributionType(address eolVault, address reward) external view returns (IRewardHandler.DistributionType);
 
   /**
    * @notice Returns the reward handler for the given EOLVault and reward
    * @param eolVault The EOLVault address
    * @param reward The reward token address
-   * @return handler_ Routed reward handler
    */
-  function route(address eolVault, address reward) external view returns (IRewardHandler handler_);
+  function route(address eolVault, address reward) external view returns (IRewardHandler);
 
   /**
    * @notice Returns the default reward handler for the given distribution type
    * @param distributionType_ The distribution type
-   * @return defaultHandler_ The default reward handler
    */
-  function defaultHandler(IRewardHandler.DistributionType distributionType_)
-    external
-    view
-    returns (IRewardHandler defaultHandler_);
+  function defaultHandler(IRewardHandler.DistributionType distributionType_) external view returns (IRewardHandler);
 
   /**
    * @notice Iterates over the registered reward handlers for the given distribution type
    * @dev It will returns the entire list of handlers if the offset + size is greater than the number of handlers
    * @param offset The offset to start from
    * @param size The number of handlers to return
-   * @return handlers_ The reward handlers
    */
-  function allowedHandlers(uint256 offset, uint256 size) external view returns (IRewardHandler[] memory handlers_);
+  function allowedHandlers(uint256 offset, uint256 size) external view returns (IRewardHandler[] memory);
 
   /**
    * @notice Checks if the reward handler is allowed
    * @param handler_ The reward handler
-   * @return isRegistered_ A boolean indicating whether the handler is registered
    */
-  function isHandlerAllowed(IRewardHandler handler_) external view returns (bool isRegistered_);
+  function isHandlerAllowed(IRewardHandler handler_) external view returns (bool);
 }
 
 /**

--- a/src/interfaces/hub/reward/ITreasury.sol
+++ b/src/interfaces/hub/reward/ITreasury.sol
@@ -20,22 +20,20 @@ interface ITreasuryStorageV1 {
    * @notice Returns the current holdings of the reward token for the EOLVault
    * @param eolVault The EOLVault address
    * @param reward The reward token address
-   * @return balance The current holdings of the reward token
    */
-  function balances(address eolVault, address reward) external view returns (uint256 balance);
+  function balances(address eolVault, address reward) external view returns (uint256);
 
   /**
-   * @notice Returns the management log history of the reward token for the EOLVault
+   * @notice Returns the management log histories of the reward token for the EOLVault
    * @param eolVault The EOLVault address
    * @param reward The reward token address
    * @param offset The offset to start from
    * @param size The number of logs to return
-   * @return history_ The management log history of the reward token
    */
   function history(address eolVault, address reward, uint256 offset, uint256 size)
     external
     view
-    returns (HistoryResponse[] memory history_);
+    returns (HistoryResponse[] memory);
 }
 
 /**

--- a/src/interfaces/twab/ITWABSnapshots.sol
+++ b/src/interfaces/twab/ITWABSnapshots.sol
@@ -47,7 +47,7 @@ interface ITWABSnapshots is IERC5805 {
    * @param timepoint The timestamp at which to get the snapshot.
    * @return balance The balance of the account at the given timepoint.
    */
-  function balanceSnapshot(address account, uint256 timepoint) external view returns (uint208 balance);
+  function balanceSnapshot(address account, uint256 timepoint) external view returns (uint208);
 
   /**
    * @notice Returns the delegate snapshot for an account at the current time.

--- a/src/lib/LibRedeemQueue.sol
+++ b/src/lib/LibRedeemQueue.sol
@@ -88,7 +88,7 @@ library LibRedeemQueue {
     return x.accumulatedAssets <= q.totalReservedAssets;
   }
 
-  function get(Queue storage q, uint256 itemIndex) internal view returns (Request memory req) {
+  function get(Queue storage q, uint256 itemIndex) internal view returns (Request memory) {
     require(itemIndex < q.size, LibRedeemQueue__IndexOutOfRange(itemIndex, 0, q.size - 1));
     return q.data[itemIndex];
   }
@@ -98,7 +98,7 @@ library LibRedeemQueue {
     return idx.data[i];
   }
 
-  function get(Queue storage q, Index storage idx, uint256 i) internal view returns (Request memory req) {
+  function get(Queue storage q, Index storage idx, uint256 i) internal view returns (Request memory) {
     return get(q, get(idx, i));
   }
 
@@ -149,8 +149,8 @@ library LibRedeemQueue {
     return totalRequested > totalReserved ? totalRequested - totalReserved : 0;
   }
 
-  function index(Queue storage q, address recipient) internal view returns (Index storage idx) {
-    idx = q.indexes[recipient];
+  function index(Queue storage q, address recipient) internal view returns (Index storage) {
+    Index storage idx = q.indexes[recipient];
     require(idx.size != 0, LibRedeemQueue__EmptyIndex(recipient));
     return idx;
   }

--- a/src/twab/TWABSnapshots.sol
+++ b/src/twab/TWABSnapshots.sol
@@ -72,7 +72,7 @@ abstract contract TWABSnapshots is
     return uint256(amount);
   }
 
-  function getPastTotalSupply(uint256 timepoint) external view virtual returns (uint256 balance) {
+  function getPastTotalSupply(uint256 timepoint) external view virtual returns (uint256) {
     (uint208 amount,,) = _totalSupplySnapshot(_getTWABSnapshotsStorageV1(), timepoint);
     return uint256(amount);
   }
@@ -96,7 +96,7 @@ abstract contract TWABSnapshots is
     return _totalSupplySnapshot(_getTWABSnapshotsStorageV1(), timepoint);
   }
 
-  function balanceSnapshot(address account, uint256 timepoint) external view virtual returns (uint208 balance) {
+  function balanceSnapshot(address account, uint256 timepoint) external view virtual returns (uint208) {
     return _balanceSnapshot(_getTWABSnapshotsStorageV1(), account, timepoint);
   }
 

--- a/src/twab/TWABSnapshotsStorageV1.sol
+++ b/src/twab/TWABSnapshotsStorageV1.sol
@@ -47,7 +47,7 @@ abstract contract TWABSnapshotsStorageV1 {
   function _balanceSnapshot(TWABSnapshotsStorageV1_ storage $, address account, uint256 timestamp)
     internal
     view
-    returns (uint208 balance)
+    returns (uint208)
   {
     uint48 currentTimestamp = clock();
     require(timestamp <= currentTimestamp, ITWABSnapshots.ERC5805FutureLookup(timestamp, currentTimestamp));


### PR DESCRIPTION
I didn't touch `StdStrategy` because i want to reduce diff from eol beta.