### PR TITLE
✨ Add `yarn abi` command to extract abi files from build output

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -74,3 +74,5 @@ script/foundry/Test.s.sol
 dependencies
 
 **/.DS_Store
+
+abis

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
   "scripts": {
     "prepare": "husky",
     "build": "forge build",
+    "abi": "mkdir -p abis && forge build --force --skip script --skip test --extra-output-files abi && find ./out -type f | grep '.abi.json' | xargs -I % cp % abis",
     "lint": "forge fmt && yarn prettier && yarn format-json && yarn sort-imports",
     "lint:check": "forge fmt --check && yarn prettier:check && yarn format-json:check && yarn sort-imports:check",
     "prettier": "prettier . --write",


### PR DESCRIPTION
1. I used this to generate required ABI files for `mitosis-org/protocol-subgraph`