### PR TITLE
✨ Add configurable decimals feature to HubAsset

### DIFF
--- a/src/hub/core/HubAsset.sol
+++ b/src/hub/core/HubAsset.sol
@@ -17,17 +17,25 @@ contract HubAsset is Ownable2StepUpgradeable, ERC20TWABSnapshots, HubAssetStorag
     address supplyManager_,
     address delegationRegistry_,
     string memory name_,
-    string memory symbol_
+    string memory symbol_,
+    uint8 decimals_
   ) external initializer {
     __Ownable2Step_init();
     _transferOwnership(owner_);
     __ERC20TWABSnapshots_init(delegationRegistry_, name_, symbol_);
     _getStorageV1().supplyManager = supplyManager_;
+    StorageV1 storage $ = _getStorageV1();
+    $.supplyManager = supplyManager_;
+    $.decimals = decimals_;
   }
 
   modifier onlySupplyManager() {
     require(_msgSender() == _getStorageV1().supplyManager, StdError.Unauthorized());
     _;
+  }
+
+  function decimals() public view override returns (uint8) {
+    return _getStorageV1().decimals;
   }
 
   function supplyManager() external view returns (address) {

--- a/src/hub/core/HubAssetStorageV1.sol
+++ b/src/hub/core/HubAssetStorageV1.sol
@@ -7,6 +7,7 @@ abstract contract HubAssetStorageV1 {
   using ERC7201Utils for string;
 
   struct StorageV1 {
+    uint8 decimals;
     address supplyManager;
   }
 

--- a/test/hub/core/AssetManager.t.sol
+++ b/test/hub/core/AssetManager.t.sol
@@ -87,7 +87,7 @@ contract AssetManagerTest is Toolkit {
             address(tokenImpl),
             address(_proxyAdmin),
             abi.encodeCall(
-              _token.initialize, (owner, address(_assetManager), address(_delegationRegistry), 'Token', 'TKN')
+              _token.initialize, (owner, address(_assetManager), address(_delegationRegistry), 'Token', 'TKN', 18)
             )
           )
         )

--- a/test/hub/core/HubAsset.t.sol
+++ b/test/hub/core/HubAsset.t.sol
@@ -15,6 +15,7 @@ import { MockDelegationRegistry } from '../../mock/MockDelegationRegistry.t.sol'
 
 contract HubAssetTest is Test {
   HubAsset hubAsset;
+  HubAsset usdc;
 
   MockDelegationRegistry internal _delegationRegistry;
   ProxyAdmin internal _proxyAdmin;
@@ -34,7 +35,23 @@ contract HubAssetTest is Test {
           new TransparentUpgradeableProxy(
             address(hubAssetImpl),
             address(_proxyAdmin),
-            abi.encodeCall(hubAsset.initialize, (owner, address(this), address(_delegationRegistry), 'Token', 'TKN'))
+            abi.encodeCall(
+              hubAsset.initialize, (owner, address(this), address(_delegationRegistry), 'Token', 'TKN', 18)
+            )
+          )
+        )
+      )
+    );
+
+    usdc = HubAsset(
+      payable(
+        address(
+          new TransparentUpgradeableProxy(
+            address(hubAssetImpl),
+            address(_proxyAdmin),
+            abi.encodeCall(
+              hubAsset.initialize, (owner, address(this), address(_delegationRegistry), 'USD Coin', 'USDC', 6)
+            )
           )
         )
       )
@@ -45,6 +62,10 @@ contract HubAssetTest is Test {
     assertEq(hubAsset.name(), 'Token');
     assertEq(hubAsset.symbol(), 'TKN');
     assertEq(hubAsset.decimals(), 18);
+
+    assertEq(usdc.name(), 'USD Coin');
+    assertEq(usdc.symbol(), 'USDC');
+    assertEq(usdc.decimals(), 6);
   }
 
   function test_mint() public {

--- a/test/hub/eol/OptOutQueue.t.sol
+++ b/test/hub/eol/OptOutQueue.t.sol
@@ -45,7 +45,7 @@ contract OptOutQueueTest is Test {
       _proxy(
         address(new HubAsset()),
         abi.encodeCall(
-          HubAsset.initialize, (_owner, address(_assetManager), address(_delegationRegistry), 'Test', 'TT')
+          HubAsset.initialize, (_owner, address(_assetManager), address(_delegationRegistry), 'Test', 'TT', 18)
         ) //
       )
     );


### PR DESCRIPTION
The decimals of HubAsset must match the decimals of BranchAsset.
- EOLVault (ERC4626) returns the decimals of the underlying asset, so it does not need to be modified.

The change will be deployed to a new chain, it doesn't require an upgrade. Therefore doesn't take slot location problem.