### PR TITLE
👷‍♂️ Get rid of immutable variables and use storage variable

### DIFF
--- a/src/branch/strategy/EOLStrategyExecutorStorageV1.sol
+++ b/src/branch/strategy/EOLStrategyExecutorStorageV1.sol
@@ -3,6 +3,7 @@ pragma solidity 0.8.27;
 
 import { IERC20 } from '@oz-v5/token/ERC20/utils/SafeERC20.sol';
 
+import { IMitosisVault } from '../../interfaces/branch/IMitosisVault.sol';
 import { IEOLStrategyExecutor } from '../../interfaces/branch/strategy/IEOLStrategyExecutor.sol';
 import { ERC7201Utils } from '../../lib/ERC7201Utils.sol';
 
@@ -19,6 +20,9 @@ abstract contract EOLStrategyExecutorStorageV1 {
   }
 
   struct StorageV1 {
+    IMitosisVault vault;
+    IERC20 asset;
+    address hubEOLVault;
     address strategist;
     address emergencyManager;
     StrategyRegistry strategies;

--- a/test/branch/strategy/EOLStrategyExecutor.t.sol
+++ b/test/branch/strategy/EOLStrategyExecutor.t.sol
@@ -58,15 +58,17 @@ contract MitosisVaultTest is Toolkit {
     _token = new MockERC20TWABSnapshots();
     _token.initialize(address(_delegationRegistry), 'Token', 'TKN');
 
-    EOLStrategyExecutor eolStrategyExecutorImpl =
-      new EOLStrategyExecutor(_mitosisVault, IERC20(address(_token)), hubEOLVault);
+    EOLStrategyExecutor eolStrategyExecutorImpl = new EOLStrategyExecutor();
     _eolStrategyExecutor = EOLStrategyExecutor(
       payable(
         address(
           new TransparentUpgradeableProxy(
             address(eolStrategyExecutorImpl),
             address(_proxyAdmin),
-            abi.encodeCall(eolStrategyExecutorImpl.initialize, (owner, emergencyManager))
+            abi.encodeCall(
+              eolStrategyExecutorImpl.initialize,
+              (_mitosisVault, IERC20(address(_token)), hubEOLVault, owner, emergencyManager)
+            )
           )
         )
       )


### PR DESCRIPTION
I fully understands that we decided to use immutable variable for strategy executor, but while setting up entire stack for public testnet, i felt the thing goes very complicated than i thought. so i suggest to transit to use storage variables to manage strategy executors efficiently