### PR TITLE
✨ Validate collateral amount precision is gwei

### DIFF
--- a/src/hub/consensus-layer/ConsensusValidatorEntrypoint.sol
+++ b/src/hub/consensus-layer/ConsensusValidatorEntrypoint.sol
@@ -105,7 +105,7 @@ contract ConsensusValidatorEntrypoint is IConsensusValidatorEntrypoint, Ownable2
     verifyValkey(valkey)
   {
     require(amount > 0, StdError.InvalidParameter('amount'));
-    require(amount % 1 gwei == 0, StdError.InvalidParameter('msg.value'));
+    require(amount % 1 gwei == 0, StdError.InvalidParameter('amount'));
 
     emit MsgWithdrawCollateral(valkey, amount, receiver, receivesAt);
   }


### PR DESCRIPTION
According to EngineAPI, the withdrawal unit is gwei.
Therefore, we need to ensure the collateral is always aligned with gwei precision.

Also, the slashing logic will drop any remainder below 1 gwei to make sure the alignment.
e.g., 10 gwei collateral --(1% slashing)--> 9.9 gwei --> 9 gwei collateral





