### PR TITLE
🥢 Remove `operationIndex` in BranchTimelock

### DIFF
--- a/src/branch/governance/BranchTimelock.sol
+++ b/src/branch/governance/BranchTimelock.sol
@@ -5,30 +5,9 @@ import { AccessControlEnumerableUpgradeable } from '@ozu-v5/access/extensions/Ac
 import { TimelockControllerUpgradeable } from '@ozu-v5/governance/TimelockControllerUpgradeable.sol';
 import { UUPSUpgradeable } from '@ozu-v5/proxy/utils/UUPSUpgradeable.sol';
 
-import { ERC7201Utils } from '../../lib/ERC7201Utils.sol';
 import { StdError } from '../../lib/StdError.sol';
 
 contract BranchTimelock is TimelockControllerUpgradeable, UUPSUpgradeable {
-  using ERC7201Utils for string;
-
-  /// @custom:storage-location mitosis.storage.BranchTimelock
-  struct BranchTimelockStorage {
-    uint256 operationIndex;
-  }
-
-  // =========================== NOTE: STORAGE DEFINITIONS =========================== //
-
-  string private constant _NAMESPACE = 'mitosis.storage.BranchTimelock';
-  bytes32 private immutable _slot = _NAMESPACE.storageSlot();
-
-  function _getBranchTimelockStorage() private view returns (BranchTimelockStorage storage $) {
-    bytes32 slot = _slot;
-    // slither-disable-next-line assembly
-    assembly {
-      $.slot := slot
-    }
-  }
-
   // ============================ NOTE: INITIALIZATION FUNCTIONS ============================ //
 
   constructor() {
@@ -42,47 +21,6 @@ contract BranchTimelock is TimelockControllerUpgradeable, UUPSUpgradeable {
   {
     __UUPSUpgradeable_init();
     __TimelockController_init(minDelay, proposers, executors, admin);
-  }
-
-  // =========================== NOTE: MUTATIVE METHODS =========================== //
-
-  function schedule(address, uint256, bytes calldata, bytes32, bytes32, uint256) public pure override {
-    revert StdError.NotSupported();
-  }
-
-  function scheduleBatch(address[] calldata, uint256[] calldata, bytes[] calldata, bytes32, bytes32, uint256)
-    public
-    pure
-    override
-  {
-    revert StdError.NotSupported();
-  }
-
-  function schedule(address target, uint256 value, bytes calldata data, bytes32 predecessor, uint256 delay)
-    public
-    onlyRole(PROPOSER_ROLE)
-  {
-    BranchTimelockStorage storage $ = _getBranchTimelockStorage();
-    super.schedule(target, value, data, predecessor, _salt($), delay);
-    $.operationIndex++;
-  }
-
-  function scheduleBatch(
-    address[] calldata targets,
-    uint256[] calldata values,
-    bytes[] calldata payloads,
-    bytes32 predecessor,
-    uint256 delay
-  ) public onlyRole(PROPOSER_ROLE) {
-    BranchTimelockStorage storage $ = _getBranchTimelockStorage();
-    super.scheduleBatch(targets, values, payloads, predecessor, _salt($), delay);
-    $.operationIndex++;
-  }
-
-  // =========================== NOTE: INTERNAL METHODS =========================== //
-
-  function _salt(BranchTimelockStorage storage $) internal view returns (bytes32) {
-    return bytes32($.operationIndex);
   }
 
   function _authorizeUpgrade(address) internal override onlyRole(DEFAULT_ADMIN_ROLE) { }

--- a/src/branch/governance/GovernanceEntrypoint.sol
+++ b/src/branch/governance/GovernanceEntrypoint.sol
@@ -49,7 +49,12 @@ contract GovernanceEntrypoint is IGovernanceEntrypoint, GasRouter, UUPSUpgradeab
     if (msgType == MsgType.MsgDispatchGovernanceExecution) {
       MsgDispatchGovernanceExecution memory decoded = msg_.decodeDispatchGovernanceExecution();
       _timelock.scheduleBatch(
-        _convertBytes32ArrayToAddressArray(decoded.targets), decoded.values, decoded.data, 0, _timelock.getMinDelay()
+        _convertBytes32ArrayToAddressArray(decoded.targets),
+        decoded.values,
+        decoded.data,
+        decoded.predecessor,
+        decoded.salt,
+        _timelock.getMinDelay()
       );
     }
   }

--- a/src/hub/governance/BranchGovernanceEntrypoint.sol
+++ b/src/hub/governance/BranchGovernanceEntrypoint.sol
@@ -58,12 +58,16 @@ contract BranchGovernanceEntrypoint is
     uint256 chainId,
     address[] calldata targets,
     bytes[] calldata data,
-    uint256[] calldata values
+    uint256[] calldata values,
+    bytes32 predecessor,
+    bytes32 salt
   ) external onlyRole(MANAGER_ROLE) onlyDispatchable(chainId) {
     bytes memory enc = MsgDispatchGovernanceExecution({
       targets: _convertAddressArrayToBytes32Array(targets),
       values: values,
-      data: data
+      data: data,
+      predecessor: predecessor,
+      salt: salt
     }).encode();
     _dispatchToBranch(chainId, enc);
   }

--- a/src/interfaces/hub/governance/IBranchGovernanceEntrypoint.sol
+++ b/src/interfaces/hub/governance/IBranchGovernanceEntrypoint.sol
@@ -6,6 +6,8 @@ interface IBranchGovernanceEntrypoint {
     uint256 chainId,
     address[] calldata targets,
     bytes[] calldata data,
-    uint256[] calldata values
+    uint256[] calldata values,
+    bytes32 predecessor,
+    bytes32 salt
   ) external;
 }

--- a/src/message/Message.sol
+++ b/src/message/Message.sol
@@ -87,6 +87,8 @@ struct MsgDispatchGovernanceExecution {
   bytes32[] targets;
   uint256[] values;
   bytes[] data;
+  bytes32 predecessor;
+  bytes32 salt;
 }
 
 library Message {


### PR DESCRIPTION
In the case where a proposal is made through BranchGovernance on the hub, if the salt is determined on the branch, it becomes difficult for us to handle the case where both the propose and execute actions are processed in a single message. Therefore, I decided to have the hub provide the salt, and the branch simply performs the action accordingly.