### PR TITLE
🐞 Validator Weight Index

### DIFF
--- a/src/hub/validator/ValidatorContributionFeed.sol
+++ b/src/hub/validator/ValidatorContributionFeed.sol
@@ -171,7 +171,7 @@ contract ValidatorContributionFeed is
       require(index == 0, IValidatorContributionFeed__InvalidWeightAddress());
 
       reward.weights.push(weight);
-      reward.weightByValAddr[weight.addr] = i;
+      reward.weightByValAddr[weight.addr] = i + 1;
       checker.totalWeight += weight.weight;
     }
 


### PR DESCRIPTION
https://github.com/mitosis-org/protocol/blob/98c71ca1b0a6c15ce6fd1beda4be3210685e9459/src/hub/validator/ValidatorContributionFeed.sol#L149-L153

Because empty weight is pushed when `initializeReport`
I think we have to add 1 to index when publishing to get correct weight of validator


https://github.com/mitosis-org/protocol/blob/98c71ca1b0a6c15ce6fd1beda4be3210685e9459/src/hub/validator/ValidatorContributionFeed.sol#L110-L115