### PR TITLE
🥢 Default implementation of `pause` and `unpause` & `_authorizePause`

### DIFF
--- a/src/branch/MitosisVault.sol
+++ b/src/branch/MitosisVault.sol
@@ -261,6 +261,8 @@ contract MitosisVault is IMitosisVault, Pausable, Ownable2StepUpgradeable, UUPSU
 
   function _authorizeUpgrade(address) internal override onlyOwner { }
 
+  function _authorizePause(address) internal view override onlyOwner { }
+
   function setEntrypoint(address entrypoint_) external onlyOwner {
     _getStorageV1().entrypoint = IMitosisVaultEntrypoint(entrypoint_);
     emit EntrypointSet(address(entrypoint_));
@@ -325,14 +327,6 @@ contract MitosisVault is IMitosisVault, Pausable, Ownable2StepUpgradeable, UUPSU
     StorageV1 storage $ = _getStorageV1();
     _assertMatrixInitialized($, hubMatrixVault);
     return _resumeMatrix($, hubMatrixVault, action);
-  }
-
-  function pause() external onlyOwner {
-    _pause();
-  }
-
-  function unpause() external onlyOwner {
-    _unpause();
   }
 
   //=========== NOTE: INTERNAL FUNCTIONS ===========//

--- a/src/hub/core/AssetManager.sol
+++ b/src/hub/core/AssetManager.sol
@@ -214,6 +214,8 @@ contract AssetManager is IAssetManager, Pausable, Ownable2StepUpgradeable, UUPSU
 
   function _authorizeUpgrade(address) internal override onlyOwner { }
 
+  function _authorizePause(address) internal view override onlyOwner { }
+
   function initializeAsset(uint256 chainId, address hubAsset) external onlyOwner {
     _assertNotPaused();
 
@@ -289,14 +291,6 @@ contract AssetManager is IAssetManager, Pausable, Ownable2StepUpgradeable, UUPSU
 
   function setStrategist(address matrixVault, address strategist) external onlyOwner {
     _setStrategist(_getStorageV1(), matrixVault, strategist);
-  }
-
-  function pause() external onlyOwner {
-    _pause();
-  }
-
-  function unpause() external onlyOwner {
-    _unpause();
   }
 
   //=========== NOTE: INTERNAL FUNCTIONS ===========//

--- a/src/hub/matrix/MatrixVault.sol
+++ b/src/hub/matrix/MatrixVault.sol
@@ -121,11 +121,7 @@ abstract contract MatrixVault is MatrixVaultStorageV1, ERC4626, Ownable2StepUpgr
     return assets;
   }
 
-  function pause() external onlyOwner {
-    _pause();
-  }
+  // general overrides
 
-  function unpause() external onlyOwner {
-    _unpause();
-  }
+  function _authorizePause(address) internal view override onlyOwner { }
 }

--- a/src/hub/matrix/ReclaimQueue.sol
+++ b/src/hub/matrix/ReclaimQueue.sol
@@ -111,21 +111,7 @@ contract ReclaimQueue is IReclaimQueue, Pausable, Ownable2StepUpgradeable, UUPSU
 
   function _authorizeUpgrade(address) internal override onlyOwner { }
 
-  function pause() external onlyOwner {
-    _pause();
-  }
-
-  function pause(bytes4 sig) external onlyOwner {
-    _pause(sig);
-  }
-
-  function unpause() external onlyOwner {
-    _unpause();
-  }
-
-  function unpause(bytes4 sig) external onlyOwner {
-    _unpause(sig);
-  }
+  function _authorizePause(address) internal view override onlyOwner { }
 
   function enable(address matrixVault) external onlyOwner {
     _enableQueue(_getStorageV1(), matrixVault);

--- a/test/lib/Pausable.t.sol
+++ b/test/lib/Pausable.t.sol
@@ -10,21 +10,7 @@ contract PausableContract is Pausable {
     __Pausable_init();
   }
 
-  function pause() external {
-    _pause();
-  }
-
-  function pause(bytes4 sig) external {
-    _pause(sig);
-  }
-
-  function unpause() external {
-    _unpause();
-  }
-
-  function unpause(bytes4 sig) external {
-    _unpause(sig);
-  }
+  function _authorizePause(address) internal view override { }
 
   function assertNotPaused() external view {
     _assertNotPaused();


### PR DESCRIPTION
1. Not sure if the naming `_authorizePause` fits for its usage
2. We don't need to implement `pause` and `unpause` everywhere
3. We just implement `_authorizePause` if we want to verify address with complex logic