### PR TITLE
🐞 Prevent underflow

### DIFF
--- a/src/hub/validator/ValidatorStaking.sol
+++ b/src/hub/validator/ValidatorStaking.sol
@@ -281,6 +281,9 @@ contract ValidatorStaking is
 
     _assertUnstakeAmountCondition($, valAddr, payer, amount);
 
+    uint256 currentStaked = $.staked[valAddr][payer].latest();
+    require(amount <= currentStaked, IValidatorStaking__InsufficientStakedAmount(amount, currentStaked));
+
     uint48 now_ = Time.timestamp();
     uint208 amount208 = amount.toUint208();
     uint256 reqId = $.unstakeQueue[recipient].append(now_, amount208);
@@ -347,6 +350,9 @@ contract ValidatorStaking is
     require(fromValAddr != toValAddr, IValidatorStaking__RedelegateToSameValidator(fromValAddr));
 
     _assertUnstakeAmountCondition($, fromValAddr, delegator, amount);
+
+    uint256 currentStakedFrom = $.staked[fromValAddr][delegator].latest();
+    require(amount <= currentStakedFrom, IValidatorStaking__InsufficientStakedAmount(amount, currentStakedFrom));
 
     require(_manager.isValidator(fromValAddr), IValidatorStaking__NotValidator(fromValAddr));
     require(_manager.isValidator(toValAddr), IValidatorStaking__NotValidator(toValAddr));

--- a/src/interfaces/hub/validator/IValidatorStaking.sol
+++ b/src/interfaces/hub/validator/IValidatorStaking.sol
@@ -25,6 +25,7 @@ interface IValidatorStaking {
   error IValidatorStaking__RedelegateToSameValidator(address valAddr);
   error IValidatorStaking__CooldownNotPassed(uint48 lastTime, uint48 currentTime, uint48 requiredCooldown);
   error IValidatorStaking__InsufficientMinimumAmount(uint256 minAmount);
+  error IValidatorStaking__InsufficientStakedAmount(uint256 requested, uint256 available);
 
   // ========== VIEWS ========== //
 


### PR DESCRIPTION
`_opSub` does not checking underflow / overflow due to the usage of `unchecked` scope. Therefore, we need to check it in advance