### PR TITLE
🥢 Fix binding generation tool

### DIFF
--- a/tools/gen-bindings-for-chain.sh
+++ b/tools/gen-bindings-for-chain.sh
@@ -12,7 +12,7 @@ gen() {
   tmp=$(mktemp -d)
   abifile=${tmp}/${name}.abi
 
-  forge inspect ${target} abi > ${abifile}
+  forge inspect --json ${target} abi > ${abifile}
 
   abigen \
     --abi ${abifile} \


### PR DESCRIPTION
The issue:
```
➜ ./tools/gen-bindings-for-chain.sh
Warning: This is a nightly build of Foundry. It is recommended to use the latest stable version. Visit https://book.getfoundry.sh/announcements for more information. 
To mute this warning set `FOUNDRY_DISABLE_NIGHTLY_WARNING` in your environment. 

Fatal: Failed to generate ABI binding: invalid character 'â' looking for beginning of value
Warning: This is a nightly build of Foundry. It is recommended to use the latest stable version. Visit https://book.getfoundry.sh/announcements for more information. 
To mute this warning set `FOUNDRY_DISABLE_NIGHTLY_WARNING` in your environment. 

Fatal: Failed to generate ABI binding: invalid character 'â' looking for beginning of value
Warning: This is a nightly build of Foundry. It is recommended to use the latest stable version. Visit https://book.getfoundry.sh/announcements for more information. 
To mute this warning set `FOUNDRY_DISABLE_NIGHTLY_WARNING` in your environment. 

Fatal: Failed to generate ABI binding: invalid character 'â' looking for beginning of value
```

It seems that explicit `--json` parameter is necessary in latest foundry.