### PR TITLE
🥢 GenesisValidatorSet.permittedCollateralOwners

### DIFF
--- a/src/hub/validator/ValidatorManager.sol
+++ b/src/hub/validator/ValidatorManager.sol
@@ -129,9 +129,7 @@ contract ValidatorManager is
       );
 
       for (uint256 j = 0; j < genVal.permittedCollateralOwners.length; j++) {
-        _setPermittedCollateralOwner(
-          validator, genVal.permittedCollateralOwners[j].owner, genVal.permittedCollateralOwners[j].isPermitted
-        );
+        _setPermittedCollateralOwner(validator, genVal.permittedCollateralOwners[j], true);
       }
     }
   }

--- a/src/interfaces/hub/validator/IValidatorManager.sol
+++ b/src/interfaces/hub/validator/IValidatorManager.sol
@@ -62,11 +62,6 @@ interface IValidatorManager {
     uint128 pendingCommissionRateUpdateEpoch;
   }
 
-  struct PermittedCollateralOwner {
-    address owner;
-    bool isPermitted;
-  }
-
   struct GenesisValidatorSet {
     bytes pubKey;
     address operator;
@@ -75,7 +70,7 @@ interface IValidatorManager {
     bytes metadata;
     bytes signature;
     uint256 value;
-    PermittedCollateralOwner[] permittedCollateralOwners;
+    address[] permittedCollateralOwners;
   }
 
   struct SetGlobalValidatorConfigRequest {


### PR DESCRIPTION
The genesis validator set in ValidatorManager.initialize parameter, serves the purpose of transferring the consensus layer state into the contract.
This PR allows the import of collateralOwners stored in the consensus layer to execution layer.