### PR TITLE
✨Support ERC1271 on VLFStrategyExecutor

### DIFF
--- a/src/branch/strategy/VLFStrategyExecutor.sol
+++ b/src/branch/strategy/VLFStrategyExecutor.sol
@@ -1,7 +1,6 @@
 // SPDX-License-Identifier: Apache-2.0
 pragma solidity ^0.8.28;
 
-import { IERC1271 } from '@oz/interfaces/IERC1271.sol';
 import { IERC20 } from '@oz/token/ERC20/IERC20.sol';
 import { SafeERC20 } from '@oz/token/ERC20/utils/SafeERC20.sol';
 import { Address } from '@oz/utils/Address.sol';
@@ -18,7 +17,6 @@ import { Versioned } from '../../lib/Versioned.sol';
 import { VLFStrategyExecutorStorageV1 } from './VLFStrategyExecutorStorageV1.sol';
 
 contract VLFStrategyExecutor is
-  IERC1271,
   IStrategyExecutor,
   IVLFStrategyExecutor,
   Ownable2StepUpgradeable,

--- a/src/branch/strategy/VLFStrategyExecutorStorageV1.sol
+++ b/src/branch/strategy/VLFStrategyExecutorStorageV1.sol
@@ -16,6 +16,7 @@ abstract contract VLFStrategyExecutorStorageV1 {
     address hubVLFVault;
     address strategist;
     address executor;
+    address signer;
     uint256 storedTotalBalance;
     ITally tally;
   }

--- a/src/interfaces/branch/strategy/IStrategyExecutor.sol
+++ b/src/interfaces/branch/strategy/IStrategyExecutor.sol
@@ -1,16 +1,13 @@
 // SPDX-License-Identifier: Apache-2.0
 pragma solidity ^0.8.28;
 
-import { IERC20 } from '@oz/token/ERC20/IERC20.sol';
-
-import { IMitosisVault } from '../IMitosisVault.sol';
-
 interface IStrategyExecutor {
   //=========== NOTE: EVENT DEFINITIONS ===========//
 
   event TallySet(address indexed implementation);
   event StrategistSet(address indexed strategist);
   event ExecutorSet(address indexed executor);
+  event SignerSet(address indexed signer);
 
   function execute(address target, bytes calldata data, uint256 value) external returns (bytes memory result);
 

--- a/src/interfaces/branch/strategy/IVLFStrategyExecutor.sol
+++ b/src/interfaces/branch/strategy/IVLFStrategyExecutor.sol
@@ -1,13 +1,14 @@
 // SPDX-License-Identifier: Apache-2.0
 pragma solidity ^0.8.28;
 
+import { IERC1271 } from '@oz/interfaces/IERC1271.sol';
 import { IERC20 } from '@oz/token/ERC20/IERC20.sol';
 
 import { IMitosisVault } from '../IMitosisVault.sol';
 import { IStrategyExecutor } from './IStrategyExecutor.sol';
 import { ITally } from './tally/ITally.sol';
 
-interface IVLFStrategyExecutor is IStrategyExecutor {
+interface IVLFStrategyExecutor is IStrategyExecutor, IERC1271 {
   error IVLFStrategyExecutor__TallyTotalBalanceNotZero(address implementation);
   error IVLFStrategyExecutor__TallyAlreadySet(address implementation);
   error IVLFStrategyExecutor__StrategistNotSet();
@@ -19,6 +20,7 @@ interface IVLFStrategyExecutor is IStrategyExecutor {
 
   function strategist() external view returns (address);
   function executor() external view returns (address);
+  function signer() external view returns (address);
   function tally() external view returns (ITally);
   function totalBalance() external view returns (uint256);
   function storedTotalBalance() external view returns (uint256);
@@ -37,6 +39,7 @@ interface IVLFStrategyExecutor is IStrategyExecutor {
   function setTally(address implementation) external;
   function setStrategist(address strategist_) external;
   function setExecutor(address executor_) external;
+  function setSigner(address signer_) external;
   function unsetStrategist() external;
   function unsetExecutor() external;
 }

--- a/test/mock/MockVLFStrategyExecutor.t.sol
+++ b/test/mock/MockVLFStrategyExecutor.t.sol
@@ -34,6 +34,8 @@ contract MockVLFStrategyExecutor is IVLFStrategyExecutor {
 
   function executor() external view returns (address) { }
 
+  function signer() external view returns (address) { }
+
   function emergencyManager() external view returns (address) { }
 
   function tally() external view returns (ITally) { }
@@ -80,9 +82,13 @@ contract MockVLFStrategyExecutor is IVLFStrategyExecutor {
 
   function setExecutor(address executor_) external { }
 
+  function setSigner(address signer_) external { }
+
   function unsetStrategist() external { }
 
   function unsetExecutor() external { }
+
+  function isValidSignature(bytes32 hash_, bytes memory signature) external view returns (bytes4) { }
 
   function pause() external { }
 


### PR DESCRIPTION
Context: There are some DeFi protocols that requires this standard if we intended CA to interact their contracts.