### PR TITLE
🥢 Support msg type order backward compatibility

### DIFF
--- a/src/message/Message.sol
+++ b/src/message/Message.sol
@@ -6,6 +6,7 @@ enum MsgType {
   MsgInitializeAsset,
   MsgDeposit,
   MsgDepositWithSupplyVLF,
+  __Deprecated_MsgDepositWithSupplyEOL,
   MsgWithdraw,
   //=========== NOTE: VLF ===========//
   MsgInitializeVLF,
@@ -14,6 +15,7 @@ enum MsgType {
   MsgSettleVLFYield,
   MsgSettleVLFLoss,
   MsgSettleVLFExtraRewards,
+  __Deprecated_MsgInitializeEOL,
   //=========== NOTE: MITOGovernance ===========//
   MsgDispatchGovernanceExecution
 }


### PR DESCRIPTION
It is required for our backend system compatibility.

Related commit: https://github.com/mitosis-org/protocol/commit/73297e73f78c761bf6b104f235f9a635088bad59#diff-d2d438f85f8bb0cdfecaca4c564857e17cefbeb2d86f605297e283e84e2efd3e