### PR TITLE
🥢 Add `approve` to ManagerDecoderAndSanitizer

### DIFF
--- a/src/branch/strategy/manager/DecodersAndSanitizers/ManagerDecoderAndSanitizer.sol
+++ b/src/branch/strategy/manager/DecodersAndSanitizers/ManagerDecoderAndSanitizer.sol
@@ -9,4 +9,8 @@ contract ManagerDecoderAndSanitizer is BaseDecoderAndSanitizer {
   function withdraw(uint256, address receiver) external pure returns (bytes memory addressesFound) {
     addressesFound = abi.encodePacked(receiver);
   }
+
+  function approve(address spender, uint256) external pure returns (bytes memory addressesFound) {
+    addressesFound = abi.encodePacked(spender);
+  }
 }


### PR DESCRIPTION
We must also be able to perform an approve in order to call Manager.deposit.