### PR TITLE
🐞 Prevent potential hash collisions in `MerkleRewardDistributor._leaf()`

### DIFF
--- a/src/hub/reward/MerkleRewardDistributor.sol
+++ b/src/hub/reward/MerkleRewardDistributor.sol
@@ -345,8 +345,8 @@ contract MerkleRewardDistributor is
   {
     // double-hashing to prevent second preimage attacks:
     // https://flawed.net.nz/2018/02/21/attacking-merkle-trees-with-a-second-preimage-attack/
-    bytes32 rewardsHash = keccak256(abi.encode(rewards));
-    bytes32 amountsHash = keccak256(abi.encode(amounts));
+    bytes32 rewardsHash = keccak256(abi.encodePacked(rewards));
+    bytes32 amountsHash = keccak256(abi.encodePacked(amounts));
     return keccak256(bytes.concat(keccak256(abi.encodePacked(receiver, stage, vault, rewardsHash, amountsHash))));
   }
 }


### PR DESCRIPTION
Previously, there could be different two cases generating same hashes:
```
// Case 1
rewards = [0x1111...1111, 0x2222...2222]
amounts = [100]

// Case 2  
rewards = [0x1111...1111]
amounts = [0x2222...2222 (as uint256), 100]
```