### PR TITLE
🐞 Fix incorrect integration of `reserveVLF()` and `previewSync()`

### DIFF
--- a/src/hub/ReclaimQueue.sol
+++ b/src/hub/ReclaimQueue.sol
@@ -176,7 +176,7 @@ contract ReclaimQueue is IReclaimQueue, Pausable, Ownable2StepUpgradeable, UUPSU
   function previewSync(address vault, uint256 requestCount) external view returns (uint256, uint256) {
     StorageV1 storage $ = _getStorageV1();
     SyncResult memory res = _calcSync($.queues[vault], vault, requestCount);
-    return (res.totalSharesSynced, Math.min(res.totalAssetsOnRequest, res.totalAssetsOnReserve));
+    return (res.totalSharesSynced, res.totalAssetsOnReserve);
   }
 
   function previewSyncWithBudget(address vault, uint256 budget)
@@ -195,7 +195,7 @@ contract ReclaimQueue is IReclaimQueue, Pausable, Ownable2StepUpgradeable, UUPSU
       Request memory req = q$.items[reqId];
 
       uint256 shares = reqId == 0 ? req.sharesAcc : req.sharesAcc - q$.items[reqId - 1].sharesAcc;
-      uint256 assets = Math.min(req.assets, IERC4626(vault).previewRedeem(shares));
+      uint256 assets = IERC4626(vault).previewRedeem(shares);
 
       if (budget < assets) break;
       budget -= assets;

--- a/test/hub/ReclaimQueue.t.sol
+++ b/test/hub/ReclaimQueue.t.sol
@@ -455,7 +455,7 @@ contract ReclaimQueueTest is ReclaimQueueTestHelper, Toolkit {
     {
       (uint256 totalSharesSynced, uint256 totalAssetsSynced) = queue.previewSync(vault, 100);
       assertEq(totalSharesSynced, expectedSharesSynced, 'totalSharesSynced');
-      assertEq(totalAssetsSynced, expectedAssetsOnRequest, 'totalAssetsSynced');
+      assertEq(totalAssetsSynced, expectedAssetsOnReserve, 'totalAssetsSynced');
     }
 
     // check actual result

--- a/test/hub/ReclaimQueue.t.sol
+++ b/test/hub/ReclaimQueue.t.sol
@@ -340,6 +340,7 @@ contract ReclaimQueueTest is ReclaimQueueTestHelper, Toolkit {
       }
 
       asset.assertERC20Transfer(address(queue), expectedAssets);
+      assertEq(SimpleERC4626Vault(vault).balanceOf(address(collector)), 0, 'collector shares after sync #1');
       _compareSyncLog(queue.queueSyncLog(vault, 0), makeSyncLog(_now(), 0, 2, 200 ether, 300 ether, 300 ether));
     }
 
@@ -373,6 +374,7 @@ contract ReclaimQueueTest is ReclaimQueueTestHelper, Toolkit {
       }
 
       asset.assertERC20Transfer(address(queue), expectedAssets);
+      assertEq(SimpleERC4626Vault(vault).balanceOf(address(collector)), 0, 'collector shares after sync #2');
       _compareSyncLog(queue.queueSyncLog(vault, 1), makeSyncLog(_now(), 2, 3, 300 ether, 100 ether, 100 ether));
     }
 
@@ -424,6 +426,8 @@ contract ReclaimQueueTest is ReclaimQueueTestHelper, Toolkit {
     }
 
     asset.assertERC20Transfer(address(queue), expectedAssetsOnReserve);
+    // Loss case: no extra shares collected
+    assertEq(SimpleERC4626Vault(vault).balanceOf(address(collector)), 0, 'collector shares after loss sync');
     _compareSyncLog(queue.queueSyncLog(vault, 0), makeSyncLog(_now(), 0, 3, 300 ether, totalSupply, totalAssets));
   }
 


### PR DESCRIPTION
`reserveVLF()` requires `simulatedTotalReservedAssets <= idle` to ensure there are enough funds in vlfVault.
```solidity
  function reserveVLF(address vlfVault, uint256 claimCount) external whenNotPaused {
    StorageV1 storage $ = _getStorageV1();

    _assertOnlyStrategist($, vlfVault);

    uint256 idle = _vlfIdle($, vlfVault);
    (, uint256 simulatedTotalReservedAssets) = $.reclaimQueue.previewSync(vlfVault, claimCount);
    require(simulatedTotalReservedAssets > 0, IAssetManager__NothingToVLFReserve(vlfVault));
    require(simulatedTotalReservedAssets <= idle, IAssetManager__VLFLiquidityInsufficient(vlfVault));
```
`simulatedTotalReservedAssets` will be `min(totalAssetsOnRequest,totalAssetsOnReserve)`.
```solidity
  function previewSync(address vault, uint256 requestCount) external view returns (uint256, uint256) {
    StorageV1 storage $ = _getStorageV1();
    SyncResult memory res = _calcSync($.queues[vault], vault, requestCount);
    return (res.totalSharesSynced, Math.min(res.totalAssetsOnRequest, res.totalAssetsOnReserve));
  }
```
The problem here is that after modification, `sync()` no longer only withdraws `min(totalAssetsOnRequest,totalAssetsOnReserve)`, but also withdraws `totalAssetsOnReserve-totalAssetsOnRequest` to the ReclaimQueueCollector.
```solidity
  function _sync(StorageV1 storage $, address vault, uint256 requestCount) internal returns (SyncResult memory) {
    QueueState storage q$ = $.queues[vault];
    require(q$.items.length != 0, IReclaimQueue__NothingToSync());

    SyncResult memory res = _calcSync(q$, vault, requestCount);
    require(res.reqIdTo > q$.offset, IReclaimQueue__NothingToSync());

    uint256 withdrawAmount = Math.min(res.totalAssetsOnRequest, res.totalAssetsOnReserve);
    IERC4626(vault).withdraw(withdrawAmount, address(this), address(this));

    if (res.totalAssetsOnRequest < res.totalAssetsOnReserve) {
      uint256 assetsCollected = res.totalAssetsOnReserve - res.totalAssetsOnRequest;
      uint256 sharesCollected = IERC4626(vault).previewWithdraw(assetsCollected);

      IERC20Metadata(vault).forceApprove($.collector, sharesCollected);
      IReclaimQueueCollector($.collector).collect(vault, vault, sharesCollected);
      IERC20Metadata(vault).forceApprove($.collector, 0);
    }
```
Consider totalAssetsOnRequest == 1000, totalAssetsOnReserve == 1100, vlfVault.totalAssets() == 8000, vlfVault.allocation == 7000, so idle == 8000 - 7000 = 1000.
`reserveVLF()` is called to withdraw 1000, but actually withdraws 1100. At this point, vlfVault.totalAssets() == 6900, causing `_vlfIdle()` to underflow, which invariably causes reserveVLF() and allocateVLF() to fail.
```solidity
  function _vlfIdle(StorageV1 storage $, address vlfVault) internal view returns (uint256) {
    uint256 total = IVLFVault(vlfVault).totalAssets();
    uint256 allocated = $.vlfStates[vlfVault].allocation;

    return total - allocated;
  }
```