### PR TITLE
🐞 Use `convertToShares` (floors) for collector transfer to avoid insufficient-balance reverts when share price increases

### DIFF
--- a/src/hub/ReclaimQueue.sol
+++ b/src/hub/ReclaimQueue.sol
@@ -556,7 +556,7 @@ contract ReclaimQueue is IReclaimQueue, Pausable, Ownable2StepUpgradeable, UUPSU
 
     if (res.totalAssetsOnRequest < res.totalAssetsOnReserve) {
       uint256 assetsCollected = res.totalAssetsOnReserve - res.totalAssetsOnRequest;
-      uint256 sharesCollected = IERC4626(vault).previewWithdraw(assetsCollected);
+      uint256 sharesCollected = IERC4626(vault).convertToShares(assetsCollected);
 
       IERC20Metadata(vault).forceApprove($.collector, sharesCollected);
       IReclaimQueueCollector($.collector).collect(vault, vault, sharesCollected);

--- a/test/hub/ReclaimQueue.t.sol
+++ b/test/hub/ReclaimQueue.t.sol
@@ -474,7 +474,7 @@ contract ReclaimQueueTest is ReclaimQueueTestHelper, Toolkit {
 
     assertEq(
       SimpleERC4626Vault(vault).balanceOf(address(collector)),
-      SimpleERC4626Vault(vault).previewWithdraw(expectedAssetsOnReserve - expectedAssetsOnRequest),
+      SimpleERC4626Vault(vault).convertToShares(expectedAssetsOnReserve - expectedAssetsOnRequest),
       'shares remain'
     );
     asset.assertERC20Transfer(address(queue), expectedAssetsOnRequest);


### PR DESCRIPTION
`ReclaimQueue._sync()` transfers excess shares to the ReclaimQueueCollector. 
```solidity
  function _sync(StorageV1 storage $, address vault, uint256 requestCount) internal returns (SyncResult memory) {
    QueueState storage q$ = $.queues[vault];
    require(q$.items.length != 0, IReclaimQueue__NothingToSync());

    SyncResult memory res = _calcSync(q$, vault, requestCount);
    require(res.reqIdTo > q$.offset, IReclaimQueue__NothingToSync());

    uint256 withdrawAmount = Math.min(res.totalAssetsOnRequest, res.totalAssetsOnReserve);
    IERC4626(vault).withdraw(withdrawAmount, address(this), address(this));

    if (res.totalAssetsOnRequest < res.totalAssetsOnReserve) {
      uint256 assetsCollected = res.totalAssetsOnReserve - res.totalAssetsOnRequest;
      uint256 sharesCollected = IERC4626(vault).previewWithdraw(assetsCollected);

      IERC20Metadata(vault).forceApprove($.collector, sharesCollected);
      IReclaimQueueCollector($.collector).collect(vault, vault, sharesCollected);
      IERC20Metadata(vault).forceApprove($.collector, 0);
    }
```
The problem here is that `IERC4626.previewWithdraw()` rounds up, which can cause the calculated `sharesCollected` to be greater than the actual balance, causing the transfer to fail due to insufficient balance.

Consider a user requesting to withdraw 1000 shares. At this point, 1000 shares are worth 1000 assets. Later, `sync()` is called, and the value of 1000 shares increases to 1100 assets.

`_sync()` first withdraws 1000 assets. `withdraw()` rounds up and burns 1000/1.1 = 910 shares, leaving 90 shares. Later, when transferring the remaining shares, the 100 assets are converted to 91 shares. Due to insufficient balance, the transfer fails.
```solidity
  function _sync(StorageV1 storage $, address vault, uint256 requestCount) internal returns (SyncResult memory) {
    QueueState storage q$ = $.queues[vault];
    require(q$.items.length != 0, IReclaimQueue__NothingToSync());

    SyncResult memory res = _calcSync(q$, vault, requestCount);
    require(res.reqIdTo > q$.offset, IReclaimQueue__NothingToSync());

    uint256 withdrawAmount = Math.min(res.totalAssetsOnRequest, res.totalAssetsOnReserve);
    IERC4626(vault).withdraw(withdrawAmount, address(this), address(this));

    if (res.totalAssetsOnRequest < res.totalAssetsOnReserve) {
      uint256 assetsCollected = res.totalAssetsOnReserve - res.totalAssetsOnRequest;
      uint256 sharesCollected = IERC4626(vault).previewWithdraw(assetsCollected);

      IERC20Metadata(vault).forceApprove($.collector, sharesCollected);
      IReclaimQueueCollector($.collector).collect(vault, vault, sharesCollected);
      IERC20Metadata(vault).forceApprove($.collector, 0);
    }
```