### PR TITLE
✨ Add MAX_ALLOWED_CAP to avoid overflow in maxMint

### DIFF
--- a/src/hub/vlf/VLFVaultCapped.sol
+++ b/src/hub/vlf/VLFVaultCapped.sol
@@ -18,6 +18,10 @@ contract VLFVaultCapped is VLFVault {
   using ERC7201Utils for string;
   using EnumerableSet for EnumerableSet.UintSet;
 
+  // Maximum allowed cap to prevent overflow in maxMint calculations
+  // Conservative limit that can be increased if needed in future upgrades.
+  uint256 private constant MAX_ALLOWED_CAP = type(uint256).max / 1e24;
+
   /// @custom:storage-location mitosis.storage.VLFVaultCapped
   struct VLFVaultCappedStorage {
     uint256 cap;
@@ -131,12 +135,14 @@ contract VLFVaultCapped is VLFVault {
   }
 
   function _setCap(VLFVaultCappedStorage storage $, uint256 newCap) internal {
+    require(newCap <= MAX_ALLOWED_CAP, StdError.InvalidParameter('newCap'));
     uint256 prevCap = $.cap;
     $.cap = newCap;
     emit CapSet(_msgSender(), prevCap, newCap);
   }
 
   function _setSoftCap(VLFVaultCappedStorage storage $, uint256 newSoftCap) internal {
+    require(newSoftCap <= MAX_ALLOWED_CAP, StdError.InvalidParameter('newSoftCap'));
     uint256 prevSoftCap = $.softCap;
     $.softCap = newSoftCap;
     emit SoftCapSet(prevSoftCap, newSoftCap);

--- a/src/hub/vlf/VLFVaultCapped.sol
+++ b/src/hub/vlf/VLFVaultCapped.sol
@@ -20,7 +20,7 @@ contract VLFVaultCapped is VLFVault {
 
   // Maximum allowed cap to prevent overflow in maxMint calculations
   // Conservative limit that can be increased if needed in future upgrades.
-  uint256 private constant MAX_ALLOWED_CAP = type(uint256).max / 1e24;
+  uint256 public constant MAX_ALLOWED_CAP = type(uint256).max / 1e24;
 
   /// @custom:storage-location mitosis.storage.VLFVaultCapped
   struct VLFVaultCappedStorage {

--- a/src/hub/vlf/VLFVaultCapped.sol
+++ b/src/hub/vlf/VLFVaultCapped.sol
@@ -18,9 +18,7 @@ contract VLFVaultCapped is VLFVault {
   using ERC7201Utils for string;
   using EnumerableSet for EnumerableSet.UintSet;
 
-  // Maximum allowed cap to prevent overflow in maxMint calculations
-  // Conservative limit that can be increased if needed in future upgrades.
-  uint256 public constant MAX_ALLOWED_CAP = type(uint256).max / 1e24;
+  uint256 public constant MAX_ALLOWED_CAP = type(uint256).max / 1e9;
 
   /// @custom:storage-location mitosis.storage.VLFVaultCapped
   struct VLFVaultCappedStorage {

--- a/test/hub/vlf/VLFVault.t.sol
+++ b/test/hub/vlf/VLFVault.t.sol
@@ -109,7 +109,7 @@ contract VLFVaultBasicTest is VLFVaultBaseTest {
   }
 
   function test_deposit(uint256 amount) public {
-    vm.assume(0 < amount && amount < type(uint64).max);
+    vm.assume(0 < amount && amount < capped.MAX_ALLOWED_CAP());
 
     vm.deal(user, amount);
     vm.startPrank(user);
@@ -128,7 +128,7 @@ contract VLFVaultBasicTest is VLFVaultBaseTest {
   }
 
   function test_mint(uint256 amount) public {
-    vm.assume(0 < amount && amount < type(uint64).max);
+    vm.assume(0 < amount && amount < capped.MAX_ALLOWED_CAP());
 
     vm.deal(user, amount);
     vm.startPrank(user);
@@ -254,8 +254,9 @@ contract VLFVaultCappedTest is VLFVaultBaseTest {
   }
 
   function test_deposit(uint256 cap, uint256 amount) public {
-    vm.assume(cap <= capped.MAX_ALLOWED_CAP());
-    vm.assume(0 < amount && amount < type(uint64).max);
+    uint256 maxAllowedCap = capped.MAX_ALLOWED_CAP();
+    vm.assume(cap <= maxAllowedCap);
+    vm.assume(0 < amount && amount < maxAllowedCap);
     vm.assume(amount <= cap);
 
     vm.prank(liquidityManager);
@@ -272,8 +273,9 @@ contract VLFVaultCappedTest is VLFVaultBaseTest {
   }
 
   function test_deposit_revertsIfCapExceeded(uint256 cap, uint256 amount) public {
-    vm.assume(cap <= capped.MAX_ALLOWED_CAP());
-    vm.assume(0 < amount && amount < type(uint64).max);
+    uint256 maxAllowedCap = capped.MAX_ALLOWED_CAP();
+    vm.assume(cap <= maxAllowedCap);
+    vm.assume(0 < amount && amount < maxAllowedCap);
     vm.assume(cap < amount);
 
     vm.prank(liquidityManager);
@@ -293,8 +295,7 @@ contract VLFVaultCappedTest is VLFVaultBaseTest {
 
   function test_mint(uint256 cap, uint256 amount) public {
     vm.assume(cap <= capped.MAX_ALLOWED_CAP());
-    vm.assume(0 < amount && amount < type(uint64).max);
-    vm.assume(amount <= cap && cap < type(uint64).max); // TODO:
+    vm.assume(0 < amount && amount <= cap);
 
     vm.prank(liquidityManager);
     capped.setCap(cap);
@@ -310,8 +311,9 @@ contract VLFVaultCappedTest is VLFVaultBaseTest {
   }
 
   function test_mint_revertsIfCapExceeded(uint256 cap, uint256 amount) public {
-    vm.assume(cap <= capped.MAX_ALLOWED_CAP());
-    vm.assume(0 < amount && amount < type(uint64).max);
+    uint256 maxAllowedCap = capped.MAX_ALLOWED_CAP();
+    vm.assume(cap <= maxAllowedCap);
+    vm.assume(0 < amount && amount < maxAllowedCap);
     vm.assume(amount > cap);
 
     vm.prank(liquidityManager);
@@ -618,7 +620,7 @@ contract VLFVaultCappedTest is VLFVaultBaseTest {
   }
 
   function test_depositFromChainId_onlyAssetManager(uint256 amount, uint256 chainId) public {
-    vm.assume(0 < amount && amount < type(uint64).max);
+    vm.assume(0 < amount && amount < capped.MAX_ALLOWED_CAP());
 
     vm.deal(user, amount);
     vm.startPrank(user);

--- a/test/hub/vlf/VLFVault.t.sol
+++ b/test/hub/vlf/VLFVault.t.sol
@@ -198,8 +198,9 @@ contract VLFVaultCappedTest is VLFVaultBaseTest {
     super.setUp();
 
     // Initialize soft cap as disabled by default
+    uint256 maxCap = capped.MAX_ALLOWED_CAP();
     vm.prank(liquidityManager);
-    capped.setSoftCap(type(uint256).max);
+    capped.setSoftCap(maxCap);
   }
 
   // ============================ NOTE: BASIC & HARD CAP TESTS ============================ //
@@ -217,6 +218,7 @@ contract VLFVaultCappedTest is VLFVaultBaseTest {
   }
 
   function test_setCap(uint256 amount) public {
+    vm.assume(amount <= capped.MAX_ALLOWED_CAP());
     assertEq(capped.loadCap(), 0);
 
     vm.prank(liquidityManager);
@@ -232,6 +234,7 @@ contract VLFVaultCappedTest is VLFVaultBaseTest {
   }
 
   function test_deposit(uint256 cap, uint256 amount) public {
+    vm.assume(cap <= capped.MAX_ALLOWED_CAP());
     vm.assume(0 < amount && amount < type(uint64).max);
     vm.assume(amount <= cap);
 
@@ -249,6 +252,7 @@ contract VLFVaultCappedTest is VLFVaultBaseTest {
   }
 
   function test_deposit_revertsIfCapExceeded(uint256 cap, uint256 amount) public {
+    vm.assume(cap <= capped.MAX_ALLOWED_CAP());
     vm.assume(0 < amount && amount < type(uint64).max);
     vm.assume(cap < amount);
 
@@ -268,6 +272,7 @@ contract VLFVaultCappedTest is VLFVaultBaseTest {
   }
 
   function test_mint(uint256 cap, uint256 amount) public {
+    vm.assume(cap <= capped.MAX_ALLOWED_CAP());
     vm.assume(0 < amount && amount < type(uint64).max);
     vm.assume(amount <= cap && cap < type(uint64).max); // TODO:
 
@@ -285,6 +290,7 @@ contract VLFVaultCappedTest is VLFVaultBaseTest {
   }
 
   function test_mint_revertsIfCapExceeded(uint256 cap, uint256 amount) public {
+    vm.assume(cap <= capped.MAX_ALLOWED_CAP());
     vm.assume(0 < amount && amount < type(uint64).max);
     vm.assume(amount > cap);
 
@@ -342,6 +348,7 @@ contract VLFVaultCappedTest is VLFVaultBaseTest {
   // ============================ NOTE: SOFT CAP &PREFERRED CHAIN TESTS ============================ //
 
   function test_setSoftCap(uint256 amount) public {
+    vm.assume(amount <= capped.MAX_ALLOWED_CAP());
     vm.prank(liquidityManager);
     capped.setSoftCap(amount);
 
@@ -409,6 +416,7 @@ contract VLFVaultCappedTest is VLFVaultBaseTest {
   }
 
   function test_maxDeposit_withSoftCap(uint256 hardCap, uint256 softCap) public {
+    vm.assume(hardCap <= capped.MAX_ALLOWED_CAP());
     vm.assume(softCap < hardCap);
 
     vm.startPrank(liquidityManager);
@@ -421,9 +429,11 @@ contract VLFVaultCappedTest is VLFVaultBaseTest {
   }
 
   function test_maxDeposit_softCapDisabled(uint256 hardCap) public {
+    vm.assume(hardCap <= capped.MAX_ALLOWED_CAP());
+
     vm.startPrank(liquidityManager);
     capped.setCap(hardCap);
-    capped.setSoftCap(type(uint256).max); // Disable soft cap
+    capped.setSoftCap(capped.MAX_ALLOWED_CAP()); // Disable soft cap
     vm.stopPrank();
 
     // When softCap is max, should return hardCap limit
@@ -431,6 +441,7 @@ contract VLFVaultCappedTest is VLFVaultBaseTest {
   }
 
   function test_maxDepositFromChainId_preferredChain(uint256 hardCap, uint256 softCap, uint256 chainId) public {
+    vm.assume(hardCap <= capped.MAX_ALLOWED_CAP());
     vm.assume(softCap < hardCap);
     vm.assume(chainId != 9622);
 
@@ -447,6 +458,7 @@ contract VLFVaultCappedTest is VLFVaultBaseTest {
   }
 
   function test_maxDepositFromChainId_nonPreferredChain(uint256 hardCap, uint256 softCap, uint256 chainId) public {
+    vm.assume(hardCap <= capped.MAX_ALLOWED_CAP());
     vm.assume(softCap < hardCap);
 
     vm.startPrank(liquidityManager);


### PR DESCRIPTION
Add MAX_ALLOWED_CAP to prevent overflow in `maxMint` calculations.

Overflow occurs in fullMulDiv: 
- When convertToShares() calls FixedPointMathLib.fullMulDiv(assets, totalSupply, totalAssets), the multiplication `assets * totalSupply` can exceed 512-bit representation in extreme cases.
- fullMulDiv failure condition: The function reverts when `totalAssets <= p1`, where p1 is the upper 256 bits of the 512-bit product `assets * totalSupply`.

The safety condition `p1 < totalAssets` is guaranteed when:
```
assets < (totalAssets * 2^256) / totalSupply
```
For assets:shares ratio of `1:r`, where `totalSupply = totalAssets * r * 10^6` (offset decimals 6):
```
soliditysafeMaxAssets = 2^256 / (r * 10^6)
```

With our cap of `type(uint256).max / 1e9`, the safety margin is:
```
soliditysafetyMargin = (2^256 / (r * 10^6)) / (2^256 / 1e9) = 1000 / r
```

...

Assets:Shares Ratio | r Value | Safety Margin | Scenario Description
-- | -- | -- | --
1:0.1 | 0.1 | 10,000x | profitable vault
1:0.5 | 0.5 | 2,000x | profitable vault
1:1.0 | 1.0 | 1,000x | Initial/normal state
1:2.0 | 2.0 | 500x | loss scenario
1:10 | 10.0 | 100x | loss scenario

Therefore, I considered `type(uint256).max / 1e9` to be a sufficiently safe and large value.
